### PR TITLE
Updated to arch 1.0.8

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Context/ArchBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Context/ArchBaseContext.cs
@@ -1,25 +1,28 @@
 ﻿using System;
 using Arch.Core;
 
+namespace Ecs.CSharp.Benchmark.Context.Arch_Components {
+    
+    public struct Component1
+    {
+        public int Value;
+    }
+
+    public struct Component2
+    {
+        public int Value;
+    }
+
+    public struct Component3
+    {
+        public int Value;
+    }
+}
+
 namespace Ecs.CSharp.Benchmark.Context
 {
     internal class ArchBaseContext : IDisposable
     {
-        public struct Component1
-        {
-            public int Value;
-        }
-
-        public struct Component2
-        {
-            public int Value;
-        }
-
-        public struct Component3
-        {
-            public int Value;
-        }
-
         public World World { get; }
 
         public ArchBaseContext()

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Arch.cs
@@ -2,12 +2,13 @@
 using Arch.Core;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
     public partial class CreateEntityWithOneComponent
     {
-        private static readonly Type[] _archetype = { typeof(ArchBaseContext.Component1) };
+        private static readonly Type[] _archetype = { typeof(Component1) };
 
         private ArchBaseContext _arch;
 

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Arch.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
     public partial class CreateEntityWithThreeComponents
     {
-        private static readonly Type[] _archetype = { typeof(ArchBaseContext.Component1), typeof(ArchBaseContext.Component2), typeof(ArchBaseContext.Component3) };
+        private static readonly Type[] _archetype = { typeof(Component1), typeof(Component2), typeof(Component3) };
 
         private ArchBaseContext _arch;
 

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Arch.cs
@@ -2,12 +2,13 @@
 using Arch.Core;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
     public partial class CreateEntityWithTwoComponents
     {
-        private static readonly Type[] _archetype = { typeof(ArchBaseContext.Component1), typeof(ArchBaseContext.Component2) };
+        private static readonly Type[] _archetype = { typeof(Component1), typeof(Component2) };
 
         private ArchBaseContext _arch;
 

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
-    <PackageReference Include="Arch" Version="1.0.5" />
+    <PackageReference Include="Arch" Version="1.0.8" />
     
     <PackageReference Include="Entitas" Version="1.14.1" />
 

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Arch.cs
@@ -1,23 +1,35 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Arch.Core;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
+    public struct ForEach1 : IForEach<Component1>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(ref Component1 t0)
+        {
+            ++t0.Value;
+        }
+    }
+
     public partial class SystemWithOneComponent
     {
-        private static readonly Type[] _filter = { typeof(ArchBaseContext.Component1) };
+        private static readonly Type[] _filter = { typeof(Component1) };
         private static readonly QueryDescription _queryDescription = new() { All = _filter };
 
         private ArchBaseContext _arch;
+        private static ForEach1 _forEach;
 
         [BenchmarkCategory(Categories.Arch)]
         [Benchmark]
         public void Arch()
         {
             World world = _arch.World;
-            world.Query(_queryDescription, (ref ArchBaseContext.Component1 cmp) => ++cmp.Value);
+            world.HPQuery<ForEach1, Component1>(_queryDescription, ref _forEach);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Arch.cs
@@ -1,23 +1,35 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Arch.Core;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
+    
+    public struct ForEach3 : IForEach<Component1, Component2, Component3>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(ref Component1 t0, ref Component2 t1, ref Component3 t3) {
+            t0.Value += t1.Value + t3.Value;
+        }
+    }
+    
     public partial class SystemWithThreeComponents
     {
-        private static readonly Type[] _filter = { typeof(ArchBaseContext.Component1), typeof(ArchBaseContext.Component2), typeof(ArchBaseContext.Component3) };
+        private static readonly Type[] _filter = { typeof(Component1), typeof(Component2), typeof(Component3) };
         private static readonly QueryDescription _queryDescription = new() { All = _filter };
 
         private ArchBaseContext _arch;
+        private ForEach3 _forEach3;
 
         [BenchmarkCategory(Categories.Arch)]
         [Benchmark]
         public void Arch()
         {
             World world = _arch.World;
-            world.Query(_queryDescription, (ref ArchBaseContext.Component1 c1, ref ArchBaseContext.Component1 c2, ref ArchBaseContext.Component1 c3) => c1.Value += c2.Value + c3.Value);
+            world.HPQuery<ForEach3, Component1, Component2, Component3>(_queryDescription, ref _forEach3);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Arch.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Arch.cs
@@ -1,24 +1,35 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using Arch.Core;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Context;
+using Ecs.CSharp.Benchmark.Context.Arch_Components;
 
 namespace Ecs.CSharp.Benchmark
 {
+    
+    public struct ForEach2 : IForEach<Component1, Component2>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Update(ref Component1 t0, ref Component2 t1){
+            t0.Value += t1.Value;
+        }
+    }
+    
     public partial class SystemWithTwoComponents
     {
-        private static readonly Type[] _filter = { typeof(ArchBaseContext.Component1), typeof(ArchBaseContext.Component2) };
+        private static readonly Type[] _filter = { typeof(Component1), typeof(Component2) };
         private static readonly QueryDescription _queryDescription = new() { All = _filter };
 
         private ArchBaseContext _arch;
+        private static ForEach2 _forEach2;
 
         [BenchmarkCategory(Categories.Arch)]
         [Benchmark]
         public void Arch()
         {
             World world = _arch.World;
-
-            world.Query(_queryDescription, (ref ArchBaseContext.Component1 c1, ref ArchBaseContext.Component1 c2) => c1.Value += c2.Value);
+            world.HPQuery<ForEach2, Component1, Component2>(in _queryDescription, ref _forEach2);
         }
     }
 }


### PR DESCRIPTION
Updated to arch 1.0.8 and arch is now using updated queries. 
The query logic basically gets outsourced to an interface/struct implementation. Iimproves the performance a bit. 