### PR TITLE
Fennecs

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -13,6 +13,7 @@
         public const string SveltoECS = "Svelto.ECS";
         public const string Morpeh = "Morpeh";
         public const string FlecsNet = "FlecsNet";
+        public const string Fennecs = "Fennecs";
 
         public const string CreateEntity = "CreateEntity";
         public const string System = "System";

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark.Contexts
+{
+    namespace Fennecs_Components
+    {
+        internal struct Component1
+        {
+            public int Value;
+        }
+
+        internal struct Component2
+        {
+            public int Value;
+        }
+
+        internal struct Component3
+        {
+            public int Value;
+        }
+    }
+
+    internal class FennecsBaseContext : IDisposable
+    {
+        public World World { get; }
+
+        public FennecsBaseContext()
+        {
+            World = new World();
+        }
+
+        public void Dispose()
+        {
+            World.Dispose();
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
@@ -1,0 +1,24 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithOneComponent
+    {
+        [Context] private readonly FennecsBaseContext _fennecs;
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs()
+        {
+            World world = _fennecs.World;
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                world.Spawn().Add<Component1>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
@@ -1,0 +1,28 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithThreeComponents
+    {
+        [Context]
+        private readonly FennecsBaseContext _fennecs;
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs()
+        {
+            World world = _fennecs.World;
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                world.Spawn()
+                    .Add<Component1>()
+                    .Add<Component2>()
+                    .Add<Component3>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithTwoComponents
+    {
+        [Context] private readonly FennecsBaseContext _fennecs;
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs()
+        {
+            World world = _fennecs.World;
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                world.Spawn().
+                    Add<Component1>().Add<Component2>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -33,6 +33,8 @@
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
+    <PackageReference Include="fennecs" Version="0.1.1-beta" />
+    
     <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
 
     <PackageReference Include="HypEcs" Version="1.2.1" />

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithOneComponent
+    {
+        [Context] private readonly FennecsContext _fennecs;
+
+        private sealed class FennecsContext : FennecsBaseContext
+        {
+            public Query<Component1> query;
+
+            public FennecsContext(int entityCount, int entityPadding)
+            {
+                query = World.Query<Component1>().Build();
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        World.Spawn();
+                    }
+
+                    World.Spawn().Add<Component1>();
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_ForEach()
+        {
+            _fennecs.query.For((ref Component1 comp0) => comp0.Value++);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Job()
+        {
+            _fennecs.query.Job(delegate(ref Component1 v) { v.Value++; }, 1024);
+        }
+        
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Raw()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> vectors)
+            {
+                foreach (ref var v in vectors.Span)
+                {
+                    v.Value++;
+                }
+            });
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithThreeComponents
+    {
+        [Context] private readonly FennecsContext _fennecs;
+
+        private sealed class FennecsContext : FennecsBaseContext
+        {
+            public Query<Component1, Component2, Component3> query;
+
+            public FennecsContext(int entityCount, int entityPadding)
+            {
+                query = World.Query<Component1, Component2, Component3>().Build();
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        Entity padding = World.Spawn();
+                        switch (j % 3)
+                        {
+                            case 0:
+                                padding.Add<Component1>();
+                                break;
+                            case 1:
+                                padding.Add<Component2>();
+                                break;
+                            case 2:
+                                padding.Add<Component3>();
+                                break;
+                        }
+                    }
+
+                    World.Spawn().Add<Component1>()
+                        .Add(new Component2 { Value = 1 })
+                        .Add(new Component3 { Value = 1 });
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_ForEach()
+        {
+            _fennecs.query.For((ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Job()
+        {
+            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2, ref Component3 c3) { c1.Value += c2.Value + c3.Value; }, 1024);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Raw()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v, Memory<Component3> c3v)
+            {
+                var c1vs = c1v.Span;
+                var c2vs = c2v.Span;
+                var c3vs = c3v.Span;
+                
+                for (int i = 0; i < c1vs.Length; ++i)
+                {
+                    ref Component1 c1 = ref c1vs[i];
+                    c1.Value += c2vs[i].Value + c3vs[i].Value;
+                }
+            });
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponents
+    {
+        [Context] private readonly FennecsContext _fennecs;
+
+        private sealed class FennecsContext : FennecsBaseContext
+        {
+            public Query<Component1, Component2> query;
+
+            public FennecsContext(int entityCount, int entityPadding)
+            {
+                query = World.Query<Component1, Component2>().Build();
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        Entity padding = World.Spawn();
+                        switch (j % 2)
+                        {
+                            case 0:
+                                padding.Add<Component1>();
+                                break;
+
+                            case 1:
+                                padding.Add<Component2>();
+                                break;
+                        }
+                    }
+
+                    World.Spawn().Add<Component1>().Add(new Component2 { Value = 1 });
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_ForEach()
+        {
+            _fennecs.query.For((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Job()
+        {
+            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; }, 1024);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Raw()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v)
+            {
+                var c1vs = c1v.Span;
+                var c2vs = c2v.Span;
+                for (int i = 0; i < c1vs.Length; ++i)
+                {
+                    ref Component1 c1 = ref c1vs[i];
+                    c1.Value += c2vs[i].Value;
+                }
+            });
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
+using fennecs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponentsMultipleComposition
+    {
+        [Context] private readonly FennecsContext _fennecs;
+
+        private sealed class FennecsContext : FennecsBaseContext
+        {
+            private record struct Padding1();
+
+            private record struct Padding2();
+
+            private record struct Padding3();
+
+            private record struct Padding4();
+
+            public Query<Component1, Component2> query;
+
+            public FennecsContext(int entityCount)
+            {
+                query = World.Query<Component1, Component2>().Build();
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    Entity entity = World.Spawn().Add<Component1>().Add(new Component2 { Value = 1 });
+                    switch (i % 4)
+                    {
+                        case 0:
+                            entity.Add<Padding1>();
+                            break;
+                        case 1:
+                            entity.Add<Padding2>();
+                            break;
+                        case 2:
+                            entity.Add<Padding3>();
+                            break;
+                        case 3:
+                            entity.Add<Padding4>();
+                            break;
+                    }
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_ForEach()
+        {
+            _fennecs.query.For((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Job()
+        {
+            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; }, 1024);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Raw()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v)
+            {
+                var c1vs = c1v.Span;
+                var c2vs = c2v.Span;
+                for (int i = 0; i < c1vs.Length; ++i)
+                {
+                    ref Component1 c1 = ref c1vs[i];
+                    c1.Value += c2vs[i].Value;
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Adds support for [Fennecs](https://github.com/thygrrr/fennecs/tree/main)

Seems to be bugged with non x64 architectures, so might be good to wait until this is resolved to merge https://github.com/thygrrr/fennecs/issues/4

Personal results (M1 Max). See [this](https://github.com/xentripetal/Ecs.CSharp.Benchmark) for relative performance on this machine.

> Create with one

| Method  | EntityCount | Mean     | Error    | StdDev   | Allocated |
|-------- |------------ |---------:|---------:|---------:|----------:|
| Fennecs | 100000      | 22.72 ms | 0.393 ms | 0.437 ms |  13.32 MB |

> Create with two

| Method  | EntityCount | Mean     | Error    | StdDev   | Allocated |
|-------- |------------ |---------:|---------:|---------:|----------:|
| Fennecs | 100000      | 19.64 ms | 0.391 ms | 0.384 ms |  14.82 MB |

> Create with three

| Method  | EntityCount | Mean     | Error    | StdDev   | Allocated |
|-------- |------------ |---------:|---------:|---------:|----------:|
| Fennecs | 100000      | 29.44 ms | 0.388 ms | 0.344 ms |  16.32 MB |

> System with one

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|----------:|
| **Fennecs_ForEach** | **100000**      | **0**             | **53.74 μs** |  **4.674 μs** | **0.256 μs** |         **-** |
| Fennecs_Job     | 100000      | 0             | 54.16 μs | 61.465 μs | 3.369 μs |         - |
| Fennecs_Raw     | 100000      | 0             | 46.79 μs |  0.282 μs | 0.015 μs |         - |
| **Fennecs_ForEach** | **100000**      | **10**            | **54.64 μs** |  **5.646 μs** | **0.309 μs** |         **-** |
| Fennecs_Job     | 100000      | 10            | 41.35 μs |  5.674 μs | 0.311 μs |         - |
| Fennecs_Raw     | 100000      | 10            | 46.64 μs |  2.538 μs | 0.139 μs |         - |
> System with two

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|----------:|
| **Fennecs_ForEach** | **100000**      | **0**             | **60.41 μs** |  **4.554 μs** | **0.250 μs** |         **-** |
| Fennecs_Job     | 100000      | 0             | 66.34 μs | 21.256 μs | 1.165 μs |         - |
| Fennecs_Raw     | 100000      | 0             | 55.81 μs | 16.679 μs | 0.914 μs |         - |
| **Fennecs_ForEach** | **100000**      | **10**            | **60.30 μs** |  **3.872 μs** | **0.212 μs** |         **-** |
| Fennecs_Job     | 100000      | 10            | 67.49 μs | 95.609 μs | 5.241 μs |         - |
| Fennecs_Raw     | 100000      | 10            | 56.23 μs |  4.503 μs | 0.247 μs |         - |


> System with three

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|----------:|
| **Fennecs_ForEach** | **100000**      | **0**             | **82.03 μs** |  **0.453 μs** | **0.025 μs** |         **-** |
| Fennecs_Job     | 100000      | 0             | 80.30 μs | 87.675 μs | 4.806 μs |         - |
| Fennecs_Raw     | 100000      | 0             | 70.56 μs |  1.286 μs | 0.070 μs |         - |
| **Fennecs_ForEach** | **100000**      | **10**            | **82.09 μs** |  **3.387 μs** | **0.186 μs** |         **-** |
| Fennecs_Job     | 100000      | 10            | 78.08 μs | 85.991 μs | 4.713 μs |         - |
| Fennecs_Raw     | 100000      | 10            | 70.57 μs |  3.301 μs | 0.181 μs |         - |


> System with two mixed

| Method          | EntityCount | Mean     | Error    | StdDev   | Allocated |
|---------------- |------------ |---------:|---------:|---------:|----------:|
| Fennecs_ForEach | 100000      | 62.92 μs | 5.192 μs | 0.285 μs |         - |
| Fennecs_Job     | 100000      | 64.20 μs | 5.820 μs | 0.319 μs |         - |
| Fennecs_Raw     | 100000      | 59.96 μs | 7.571 μs | 0.415 μs |         - |

