### PR TITLE
Add TinyECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tested frameworks:
 - [Myriad.ECS](https://github.com/martindevans/Myriad.ECS)
 - [RelEcs](https://github.com/Byteron/RelEcs)
 - [Svelto.ECS](https://github.com/sebas77/Svelto.ECS)
+- [TinyEcs](https://github.com/andreakarasho/TinyEcs)
 
 Removed frameworks:
 - [Entitas](https://github.com/sschmid/Entitas) removed because it was taking forever to initialize in the later tests when moved to net8, you can check older benchmark results [here](https://github.com/Doraku/Ecs.CSharp.Benchmark/tree/3574b2dfb948e941a208f77eaf9e94b73d58e6bf)

--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -15,6 +15,7 @@
         public const string Morpeh = "Morpeh";
         public const string FlecsNet = "FlecsNet";
         public const string Fennecs = "Fennecs";
+        public const string TinyEcs = "TinyEcs";
 
         public const string CreateEntity = "CreateEntity";
         public const string System = "System";

--- a/source/Ecs.CSharp.Benchmark/Contexts/TinyEcsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/TinyEcsBaseContext.cs
@@ -1,0 +1,24 @@
+using System;
+using TinyEcs;
+
+namespace Ecs.CSharp.Benchmark.Contexts
+{
+    namespace TinyEcs_Components
+    {
+        public record struct Component1(int Value);
+
+        public record struct Component2(int Value);
+
+        public record struct Component3(int Value);
+    }
+
+    public class TinyEcsBaseContext
+    {
+        public World World { get; }
+
+        public TinyEcsBaseContext()
+        {
+            World = new World();
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/TinyEcs.cs
@@ -1,0 +1,23 @@
+﻿using BenchmarkDotNet.Attributes;
+using DefaultEcs;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithOneComponent
+    {
+        [Context]
+        private readonly TinyEcsBaseContext _tinyEcs;
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _tinyEcs.World.Entity().Set<Component1>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/TinyEcs.cs
@@ -1,0 +1,26 @@
+﻿using BenchmarkDotNet.Attributes;
+using DefaultEcs;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithThreeComponents
+    {
+        [Context]
+        private readonly TinyEcsBaseContext _tinyEcs;
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _tinyEcs.World.Entity()
+                    .Set<Component1>()
+                    .Set<Component2>()
+                    .Set<Component3>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/TinyEcs.cs
@@ -1,0 +1,25 @@
+﻿using BenchmarkDotNet.Attributes;
+using DefaultEcs;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithTwoComponents
+    {
+        [Context]
+        private readonly TinyEcsBaseContext _tinyEcs;
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs()
+        {
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                _tinyEcs.World.Entity()
+                    .Set<Component1>()
+                    .Set<Component2>();
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Roslynator.Analyzers" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.10.0" PrivateAssets="all" />
+    <PackageReference Include="TinyEcs.Main" Version="1.2.0" />
   </ItemGroup>
 
   <ItemGroup Label="Benchmark">

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/TinyEcs.cs
@@ -1,0 +1,42 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+using TinyEcs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithOneComponent
+    {
+        [Context] private readonly TinyEcsContext _tinyEcs;
+
+        private sealed class TinyEcsContext : TinyEcsBaseContext
+        {
+            public TinyEcsContext(int entityCount, int entityPadding) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        World.Entity();
+                    }
+
+                    World.Entity().Set<Component1>();
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_Each()
+        {
+            _tinyEcs.World.Each((EntityView _, ref Component1 c1) => c1.Value++);
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_EachJob()
+        {
+            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1) => c1.Value++);
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/TinyEcs.cs
@@ -1,0 +1,59 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+using TinyEcs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithThreeComponents
+    {
+        [Context] private readonly TinyEcsContext _tinyEcs;
+
+        private sealed class TinyEcsContext : TinyEcsBaseContext
+        {
+            public TinyEcsContext(int entityCount, int entityPadding) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        var padding = World.Entity();
+                        switch (j % 3)
+                        {
+                            case 0:
+                                padding.Set(new Component1());
+                                break;
+
+                            case 1:
+                                padding.Set(new Component2());
+                                break;
+
+                            case 2:
+                                padding.Set(new Component3());
+                                break;
+                        }
+                    }
+
+                    World.Entity()
+                        .Set(new Component1())
+                        .Set(new Component2 { Value = 1 })
+                        .Set(new Component3 { Value = 1 });
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_Each()
+        {
+            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_EachJob()
+        {
+            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/TinyEcs.cs
@@ -1,0 +1,54 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+using TinyEcs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponents
+    {
+        [Context] private readonly TinyEcsContext _tinyEcs;
+
+        private sealed class TinyEcsContext : TinyEcsBaseContext
+        {
+            public TinyEcsContext(int entityCount, int entityPadding) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        var padding = World.Entity();
+                        switch (j % 2)
+                        {
+                            case 0:
+                                padding.Set(new Component1());
+                                break;
+
+                            case 1:
+                                padding.Set(new Component2());
+                                break;
+                        }
+                    }
+
+                    World.Entity()
+                        .Set(new Component1())
+                        .Set(new Component2 { Value = 1 });
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_Each()
+        {
+            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_EachJob()
+        {
+            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/TinyEcs.cs
@@ -1,0 +1,64 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Ecs.CSharp.Benchmark.Contexts.TinyEcs_Components;
+using TinyEcs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponentsMultipleComposition
+    {
+        [Context] private readonly TinyEcsContext _tinyEcs;
+
+        private sealed class TinyEcsContext : TinyEcsBaseContext
+        {
+            
+            private record struct Padding1();
+            private record struct Padding2();
+            private record struct Padding3();
+            private record struct Padding4();
+            
+            public TinyEcsContext(int entityCount) : base()
+            {
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    var entity = World.Entity();
+                    entity.Set<Component1>();
+                    entity.Set(new Component2 { Value = 1 });
+
+                    switch (i % 4)
+                    {
+                        case 0:
+                            entity.Set<Padding1>();
+                            break;
+
+                        case 1:
+                            entity.Set<Padding2>();
+                            break;
+
+                        case 2:
+                            entity.Set<Padding3>();
+                            break;
+
+                        case 3:
+                            entity.Set<Padding4>();
+                            break;
+                    }
+                }
+            }
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_Each()
+        {
+            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+
+        [BenchmarkCategory(Categories.TinyEcs)]
+        [Benchmark]
+        public void TinyEcs_EachJob()
+        {
+            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+    }
+}


### PR DESCRIPTION
Adds [TinyEcs](https://github.com/andreakarasho/TinyEcs), a neat ECS lib I stumbled upon that has a lot of nice features.

Sample results from my machine (M1 Max)

(Note, Myriad broke the ability to test padding across all tests by throwing an exception in its constructor, will submit a mr to fix that)


> Create with one

| Method  | EntityCount | Mean     | Error    | StdDev   | Gen0      | Allocated |
|-------- |------------ |---------:|---------:|---------:|----------:|----------:|
| TinyEcs | 100000      | 38.35 ms | 7.279 ms | 0.399 ms | 1000.0000 |   7.65 MB |

> Create with two

| Method  | EntityCount | Mean     | Error     | StdDev   | Gen0      | Gen1      | Allocated |
|-------- |------------ |---------:|----------:|---------:|----------:|----------:|----------:|
| TinyEcs | 100000      | 54.20 ms | 593.51 ms | 32.53 ms | 2000.0000 | 1000.0000 |  13.46 MB |


> Create with three

| Method  | EntityCount | Mean     | Error    | StdDev   | Gen0      | Gen1      | Allocated |
|-------- |------------ |---------:|---------:|---------:|----------:|----------:|----------:|
| TinyEcs | 100000      | 23.12 ms | 1.649 ms | 0.090 ms | 3000.0000 | 1000.0000 |  20.82 MB |

> System with one

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **41.31 μs** | **3.724 μs** | **0.204 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 27.36 μs | 3.007 μs | 0.165 μs | 0.2441 |    1552 B |


> System with two

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **66.17 μs** | **0.348 μs** | **0.019 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 30.73 μs | 4.885 μs | 0.268 μs | 0.2441 |    1552 B |

> System with three

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **68.81 μs** |  **0.761 μs** | **0.042 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 35.22 μs | 69.165 μs | 3.791 μs | 0.2441 |    1560 B |


> System with two mixed

| Method          | EntityCount | Mean     | Error     | StdDev   | Gen0   | Allocated |
|---------------- |------------ |---------:|----------:|---------:|-------:|----------:|
| TinyEcs_Each    | 100000      | 65.87 μs |  0.415 μs | 0.023 μs |      - |         - |
| TinyEcs_EachJob | 100000      | 31.43 μs | 12.589 μs | 0.690 μs | 0.3052 |    2080 B |


