### PR TITLE
Remove Myriad Exceptions

### DIFF
--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Myriad.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Myriad.cs
@@ -31,27 +31,23 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class MyriadContext : MyriadBaseContext
         {
-            public MyriadContext(int entityCount, int padding)
+            // Myriad stores components as arrays of structs, so all structs of the same type are 
+            // always sequential in memory no matter what else is attached to the entity. So no need to respect
+            // the padding input
+            public MyriadContext(int entityCount, int _)
                 : base()
             {
                 CommandBuffer cmd = new CommandBuffer(World);
                 for (int i = 0; i < entityCount; i++)
                 {
                     CommandBuffer.BufferedEntity e = cmd.Create().Set(new Component1());
-
-                    if (padding != 0)
-                    {
-                        // Myriad stores components as arrays of structs, so all structs of the same type are 
-                        // always sequential in memory no matter what else is attached to the entity.
-                        throw new NotSupportedException($"Padding makes no difference to Myriad.ECS");
-                    }
                 }
+
                 cmd.Playback().Dispose();
             }
         }
 
-        [Context]
-        private readonly MyriadContext _myriad;
+        [Context] private readonly MyriadContext _myriad;
 
         [BenchmarkCategory(Categories.Myriad)]
         [Benchmark]

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Myriad.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Myriad.cs
@@ -31,20 +31,16 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class MyriadContext : MyriadBaseContext
         {
-            public MyriadContext(int entityCount, int padding)
+            // Myriad stores components as arrays of structs, so all structs of the same type are 
+            // always sequential in memory no matter what else is attached to the entity. So no need to respect
+            // the padding input
+            public MyriadContext(int entityCount, int _)
                 : base()
             {
                 CommandBuffer cmd = new CommandBuffer(World);
                 for (int i = 0; i < entityCount; i++)
                 {
                     CommandBuffer.BufferedEntity e = cmd.Create().Set(new Component1()).Set(new Component2()).Set(new Component3());
-
-                    if (padding != 0)
-                    {
-                        // Myriad stores components as arrays of structs, so all structs of the same type are 
-                        // always sequential in memory no matter what else is attached to the entity.
-                        throw new NotSupportedException($"Padding makes no difference to Myriad.ECS");
-                    }
                 }
                 cmd.Playback().Dispose();
             }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Myriad.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Myriad.cs
@@ -31,20 +31,16 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class MyriadContext : MyriadBaseContext
         {
-            public MyriadContext(int entityCount, int padding)
+            // Myriad stores components as arrays of structs, so all structs of the same type are 
+            // always sequential in memory no matter what else is attached to the entity. So no need to respect
+            // the padding input
+            public MyriadContext(int entityCount, int _)
                 : base()
             {
                 CommandBuffer cmd = new CommandBuffer(World);
                 for (int i = 0; i < entityCount; i++)
                 {
                     CommandBuffer.BufferedEntity e = cmd.Create().Set(new Component1()).Set(new Component2());
-
-                    if (padding != 0)
-                    {
-                        // Myriad stores components as arrays of structs, so all structs of the same type are 
-                        // always sequential in memory no matter what else is attached to the entity.
-                        throw new NotSupportedException($"Padding makes no difference to Myriad.ECS");
-                    }
                 }
                 cmd.Playback().Dispose();
             }


### PR DESCRIPTION
Throwing an exception in the constructor breaks all other tests. Just ignore the padding like arch does.