### PR TITLE
Adjusts TinyEcs to match creators recommendations

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Contexts/TinyEcsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/TinyEcsBaseContext.cs
@@ -12,13 +12,18 @@ namespace Ecs.CSharp.Benchmark.Contexts
         public record struct Component3(int Value);
     }
 
-    public class TinyEcsBaseContext
+    internal class TinyEcsBaseContext : IDisposable
     {
         public World World { get; }
 
         public TinyEcsBaseContext()
         {
             World = new World();
+        }
+
+        public virtual void Dispose()
+        {
+            World?.Dispose();
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/TinyEcs.cs
@@ -11,6 +11,7 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class TinyEcsContext : TinyEcsBaseContext
         {
+            public Query<Component1> Query { get; }
             public TinyEcsContext(int entityCount, int entityPadding) : base()
             {
                 for (int i = 0; i < entityCount; ++i)
@@ -22,6 +23,8 @@ namespace Ecs.CSharp.Benchmark
 
                     World.Entity().Set<Component1>();
                 }
+
+                Query = World.Query<Component1>();
             }
         }
 
@@ -29,14 +32,14 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void TinyEcs_Each()
         {
-            _tinyEcs.World.Each((EntityView _, ref Component1 c1) => c1.Value++);
+            _tinyEcs.Query.Each((ref Component1 c1) => c1.Value++);
         }
 
         [BenchmarkCategory(Categories.TinyEcs)]
         [Benchmark]
         public void TinyEcs_EachJob()
         {
-            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1) => c1.Value++);
+            _tinyEcs.Query.EachJob((ref Component1 c1) => c1.Value++);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/TinyEcs.cs
@@ -11,6 +11,8 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class TinyEcsContext : TinyEcsBaseContext
         {
+            public Query Query { get; }
+
             public TinyEcsContext(int entityCount, int entityPadding) : base()
             {
                 for (int i = 0; i < entityCount; ++i)
@@ -38,6 +40,8 @@ namespace Ecs.CSharp.Benchmark
                         .Set(new Component1())
                         .Set(new Component2 { Value = 1 })
                         .Set(new Component3 { Value = 1 });
+                    
+                    Query = World.QueryBuilder().With<Component1>().With<Component2>().With<Component3>().Build();
                 }
             }
         }
@@ -46,14 +50,14 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void TinyEcs_Each()
         {
-            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
+            _tinyEcs.Query.Each((ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
         }
 
         [BenchmarkCategory(Categories.TinyEcs)]
         [Benchmark]
         public void TinyEcs_EachJob()
         {
-            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
+            _tinyEcs.Query.EachJob((ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/TinyEcs.cs
@@ -11,6 +11,8 @@ namespace Ecs.CSharp.Benchmark
 
         private sealed class TinyEcsContext : TinyEcsBaseContext
         {
+            public Query Query { get; }
+
             public TinyEcsContext(int entityCount, int entityPadding) : base()
             {
                 for (int i = 0; i < entityCount; ++i)
@@ -33,6 +35,7 @@ namespace Ecs.CSharp.Benchmark
                     World.Entity()
                         .Set(new Component1())
                         .Set(new Component2 { Value = 1 });
+                    Query = World.QueryBuilder().With<Component1>().With<Component2>().Build();
                 }
             }
         }
@@ -41,14 +44,14 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void TinyEcs_Each()
         {
-            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+            _tinyEcs.Query.Each((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
         }
 
         [BenchmarkCategory(Categories.TinyEcs)]
         [Benchmark]
         public void TinyEcs_EachJob()
         {
-            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+            _tinyEcs.Query.EachJob((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/TinyEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/TinyEcs.cs
@@ -16,6 +16,8 @@ namespace Ecs.CSharp.Benchmark
             private record struct Padding2();
             private record struct Padding3();
             private record struct Padding4();
+            public Query Query { get; }
+
             
             public TinyEcsContext(int entityCount) : base()
             {
@@ -44,6 +46,8 @@ namespace Ecs.CSharp.Benchmark
                             break;
                     }
                 }
+
+                Query = World.QueryBuilder().With<Component1>().With<Component2>().Build();
             }
         }
 
@@ -51,14 +55,14 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void TinyEcs_Each()
         {
-            _tinyEcs.World.Each((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+            _tinyEcs.Query.Each((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
         }
 
         [BenchmarkCategory(Categories.TinyEcs)]
         [Benchmark]
         public void TinyEcs_EachJob()
         {
-            _tinyEcs.World.EachJob((EntityView _, ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+            _tinyEcs.Query.EachJob((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
         }
     }
 }


### PR DESCRIPTION
@andreakarasho recommended changing the TinyEcs systems to use prebuilt queries and remove the Entity reference from queries.

https://github.com/Doraku/Ecs.CSharp.Benchmark/pull/29#issuecomment-2084473075

Performance Comparison:
> System with one, Old

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **41.31 μs** | **3.724 μs** | **0.204 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 27.36 μs | 3.007 μs | 0.165 μs | 0.2441 |    1552 B |

> System with one, New

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **33.85 μs** | **4.697 μs** | **0.257 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 22.52 μs | 9.674 μs | 0.530 μs | 0.2441 |    1552 B |
| **TinyEcs_Each**    | **100000**      | **10**            | **32.75 μs** | **0.731 μs** | **0.040 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 10            | 22.16 μs | 4.380 μs | 0.240 μs | 0.2441 |    1552 B |


> System with two, Old

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **66.17 μs** | **0.348 μs** | **0.019 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 30.73 μs | 4.885 μs | 0.268 μs | 0.2441 |    1552 B |

> > System with two, New

| Method          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|---------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **41.30 μs** | **0.801 μs** | **0.044 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 27.65 μs | 3.875 μs | 0.212 μs | 0.2441 |    1552 B |
| **TinyEcs_Each**    | **100000**      | **10**            | **38.34 μs** | **3.213 μs** | **0.176 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 10            | 28.47 μs | 2.466 μs | 0.135 μs | 0.2441 |    1552 B |


> System with three, Old

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **68.81 μs** |  **0.761 μs** | **0.042 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 35.22 μs | 69.165 μs | 3.791 μs | 0.2441 |    1560 B |

> System with three, New

| Method          | EntityCount | EntityPadding | Mean     | Error     | StdDev   | Gen0   | Allocated |
|---------------- |------------ |-------------- |---------:|----------:|---------:|-------:|----------:|
| **TinyEcs_Each**    | **100000**      | **0**             | **63.21 μs** | **11.610 μs** | **0.636 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 0             | 28.52 μs |  5.762 μs | 0.316 μs | 0.2441 |    1560 B |
| **TinyEcs_Each**    | **100000**      | **10**            | **65.23 μs** |  **5.717 μs** | **0.313 μs** |      **-** |         **-** |
| TinyEcs_EachJob | 100000      | 10            | 30.25 μs |  9.539 μs | 0.523 μs | 0.2441 |    1560 B |


> System with two mixed, Old

| Method          | EntityCount | Mean     | Error     | StdDev   | Gen0   | Allocated |
|---------------- |------------ |---------:|----------:|---------:|-------:|----------:|
| TinyEcs_Each    | 100000      | 65.87 μs |  0.415 μs | 0.023 μs |      - |         - |
| TinyEcs_EachJob | 100000      | 31.43 μs | 12.589 μs | 0.690 μs | 0.3052 |    2080 B |

> System with two mixed, New

| Method          | EntityCount | Mean     | Error    | StdDev   | Gen0   | Allocated |
|---------------- |------------ |---------:|---------:|---------:|-------:|----------:|
| TinyEcs_Each    | 100000      | 41.23 μs | 4.415 μs | 0.242 μs |      - |         - |
| TinyEcs_EachJob | 100000      | 27.44 μs | 8.210 μs | 0.450 μs | 0.3052 |    2080 B |
