### PR TITLE
Updated fennecs to 0.4.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ All results are obtained from the same toaster, with the same load, so compariso
 Tested frameworks:
 - [Arch](https://github.com/genaray/Arch)
 - [DefaultEcs](https://github.com/Doraku/DefaultEcs)
-- [Fennecs](https://github.com/thygrrr/fennecs)
+- [**fenn**ecs](https://fennecs.tech)
 - [Flecs.Net](https://github.com/BeanCheeseBurrito/Flecs.NET)
 - [Friflo.Engine.ECS](https://github.com/friflo/Friflo.Json.Fliox/blob/main/Engine/README.md)
 - [Leopotam.Ecs](https://github.com/Leopotam/ecs) using what I believe is a nuget package not made by the actual author and compiled in debug...

--- a/source/Ecs.CSharp.Benchmark/Capabilities.cs
+++ b/source/Ecs.CSharp.Benchmark/Capabilities.cs
@@ -1,0 +1,69 @@
+﻿using BenchmarkDotNet.Configs;
+
+namespace Ecs.CSharp.Benchmark
+{
+    /// <summary>
+    /// Capability Requirements for specific tests.
+    /// Add your own intrinsics or other system dependencies here.
+    /// </summary>
+    /// <remarks>
+    /// Usage: Add a category to it and apply exclusions in the ApplyExclusions method.
+    /// (this is an EXCLUSIVE category filter, it turns OFF all categories it matches)
+    /// Then, set your own BenchmarkCategory to include the CapabilityCategory string.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [BenchmarkCategory(
+    ///     Categories.Fennecs,
+    ///     Capabilities.Avx2
+    /// )]
+    /// public void Raw_AVX2()
+    /// </code>
+    /// </example>
+    internal static class Capabilities
+    {
+        // These are common vectorized instruction set categories.
+        // x86/x64
+        public const string Avx2 = nameof(System.Runtime.Intrinsics.X86.Avx2);
+        public const string Avx = nameof(System.Runtime.Intrinsics.X86.Avx);
+        public const string Sse3 = nameof(System.Runtime.Intrinsics.X86.Sse3);
+        public const string Sse2 = nameof(System.Runtime.Intrinsics.X86.Sse2);
+        
+        // Arm
+        public const string AdvSimd = nameof(System.Runtime.Intrinsics.Arm.AdvSimd);
+        
+        /// <summary>
+        /// This applies capability-based exclusions as filters to the config.
+        /// </summary>
+        /// <param name="self">a Benchmark Config, e.g. as used in Program.cs</param>
+        public static IConfig WithCapabilityExclusions(this IConfig self)
+        {
+            if (!System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+            {
+                self = self.AddFilter(new CategoryExclusion(Avx2));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Avx.IsSupported)
+            {
+                self = self.AddFilter(new CategoryExclusion(Avx));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Sse3.IsSupported)
+            {
+                self = self.AddFilter(new CategoryExclusion(Sse3));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Sse2.IsSupported)
+            {
+                self = self.AddFilter(new CategoryExclusion(Sse2));
+            }
+
+            if (!System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported)
+            {
+                self = self.AddFilter(new CategoryExclusion(AdvSimd));
+            }
+
+            return self;
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -6,6 +6,9 @@ using BenchmarkDotNet.Running;
 
 namespace Ecs.CSharp.Benchmark
 {
+    /// <summary>
+    /// Prefixes / ECS package names for benchmarks, used as BenchMarkDotNet categories.
+    /// </summary>
     internal static class Categories
     {
         public const string Arch = "Arch";
@@ -33,7 +36,7 @@ namespace Ecs.CSharp.Benchmark
     /// </summary>
     /// <remarks>
     /// Usage: Add a category to it and apply exclusions in the ApplyExclusions method.
-    /// (this is an EXCLUSIVE category filter)
+    /// (this is an EXCLUSIVE category filter, it turns OFF all categories it matches)
     /// Then, set your own BenchmarkCategory to include the CapabilityCategory string.
     /// </remarks>
     /// <example>
@@ -57,33 +60,35 @@ namespace Ecs.CSharp.Benchmark
         /// <summary>
         /// This applies capability-based exclusions as filters to the config.
         /// </summary>
-        /// <param name="config">a Benchmark Config, e.g. as used in Program.cs</param>
-        public static void ApplyExclusions(IConfig config)
+        /// <param name="self">a Benchmark Config, e.g. as used in Program.cs</param>
+        public static IConfig WithCapabilityExclusions(this IConfig self)
         {
             if (!System.Runtime.Intrinsics.X86.Avx2.IsSupported)
             {
-                config.AddFilter(new CategoryExclusion(Avx2));
+                self = self.AddFilter(new CategoryExclusion(Avx2));
             }
 
             if (!System.Runtime.Intrinsics.X86.Avx.IsSupported)
             {
-                config.AddFilter(new CategoryExclusion(Avx));
+                self = self.AddFilter(new CategoryExclusion(Avx));
             }
 
             if (!System.Runtime.Intrinsics.X86.Sse3.IsSupported)
             {
-                config.AddFilter(new CategoryExclusion(Sse3));
+                self = self.AddFilter(new CategoryExclusion(Sse3));
             }
 
             if (!System.Runtime.Intrinsics.X86.Sse2.IsSupported)
             {
-                config.AddFilter(new CategoryExclusion(Sse2));
+                self = self.AddFilter(new CategoryExclusion(Sse2));
             }
 
             if (!System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported)
             {
-                config.AddFilter(new CategoryExclusion(AdvSimd));
+                self = self.AddFilter(new CategoryExclusion(AdvSimd));
             }
+
+            return self;
         }
     }
     

--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -1,4 +1,10 @@
-﻿namespace Ecs.CSharp.Benchmark
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Running;
+
+namespace Ecs.CSharp.Benchmark
 {
     internal static class Categories
     {
@@ -14,10 +20,88 @@
         public const string SveltoECS = "Svelto.ECS";
         public const string Morpeh = "Morpeh";
         public const string FlecsNet = "FlecsNet";
-        public const string Fennecs = "Fennecs";
+        public const string Fennecs = "fennecs";
         public const string TinyEcs = "TinyEcs";
 
         public const string CreateEntity = "CreateEntity";
         public const string System = "System";
     }
+
+    /// <summary>
+    /// Capability Requirements for specific tests.
+    /// Add your own intrinsics or other system dependencies here.
+    /// </summary>
+    /// <remarks>
+    /// Usage: Add a category to it and apply exclusions in the ApplyExclusions method.
+    /// (this is an EXCLUSIVE category filter)
+    /// Then, set your own BenchmarkCategory to include the CapabilityCategory string.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
+    /// public void MyBenchMark() 
+    /// </code>
+    /// </example>
+    internal static class Capabilities
+    {
+        // These are common vectorized instruction set categories.
+        // x86/x64
+        public const string Avx2 = nameof(System.Runtime.Intrinsics.X86.Avx2);
+        public const string Avx = nameof(System.Runtime.Intrinsics.X86.Avx);
+        public const string Sse3 = nameof(System.Runtime.Intrinsics.X86.Sse3);
+        public const string Sse2 = nameof(System.Runtime.Intrinsics.X86.Sse2);
+        
+        // Arm
+        public const string AdvSimd = nameof(System.Runtime.Intrinsics.Arm.AdvSimd);
+        
+        /// <summary>
+        /// This applies capability-based exclusions as filters to the config.
+        /// </summary>
+        /// <param name="config">a Benchmark Config, e.g. as used in Program.cs</param>
+        public static void ApplyExclusions(IConfig config)
+        {
+            if (!System.Runtime.Intrinsics.X86.Avx2.IsSupported)
+            {
+                config.AddFilter(new CategoryExclusion(Avx2));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Avx.IsSupported)
+            {
+                config.AddFilter(new CategoryExclusion(Avx));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Sse3.IsSupported)
+            {
+                config.AddFilter(new CategoryExclusion(Sse3));
+            }
+
+            if (!System.Runtime.Intrinsics.X86.Sse2.IsSupported)
+            {
+                config.AddFilter(new CategoryExclusion(Sse2));
+            }
+
+            if (!System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported)
+            {
+                config.AddFilter(new CategoryExclusion(AdvSimd));
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Excludes a given category from benchmarks.
+    /// (used by Program.cs)
+    /// </summary>
+    /// <remarks>
+    /// When an exclusion is PRESENT, then all benchmarks that HAVE the category will be EXCLUDED.
+    /// </remarks>
+    /// <example>
+    /// <c>CategoryExclusion("foo")</c> will exclude all benchmarks that have the "foo" category.
+    /// </example>
+    public class CategoryExclusion(string category) : IFilter
+    {
+        public bool Predicate([NotNull] BenchmarkCase benchmarkCase)
+        {
+            return !benchmarkCase.Descriptor.Categories.Contains(category);
+        }
+    }    
 }

--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -41,8 +41,11 @@ namespace Ecs.CSharp.Benchmark
     /// </remarks>
     /// <example>
     /// <code>
-    /// [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-    /// public void MyBenchMark() 
+    /// [BenchmarkCategory(
+    ///     Categories.Fennecs,
+    ///     Capabilities.Avx2
+    /// )]
+    /// public void Raw_AVX2()
     /// </code>
     /// </example>
     internal static class Capabilities

--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Filters;
 using BenchmarkDotNet.Running;
 
@@ -30,71 +29,6 @@ namespace Ecs.CSharp.Benchmark
         public const string System = "System";
     }
 
-    /// <summary>
-    /// Capability Requirements for specific tests.
-    /// Add your own intrinsics or other system dependencies here.
-    /// </summary>
-    /// <remarks>
-    /// Usage: Add a category to it and apply exclusions in the ApplyExclusions method.
-    /// (this is an EXCLUSIVE category filter, it turns OFF all categories it matches)
-    /// Then, set your own BenchmarkCategory to include the CapabilityCategory string.
-    /// </remarks>
-    /// <example>
-    /// <code>
-    /// [BenchmarkCategory(
-    ///     Categories.Fennecs,
-    ///     Capabilities.Avx2
-    /// )]
-    /// public void Raw_AVX2()
-    /// </code>
-    /// </example>
-    internal static class Capabilities
-    {
-        // These are common vectorized instruction set categories.
-        // x86/x64
-        public const string Avx2 = nameof(System.Runtime.Intrinsics.X86.Avx2);
-        public const string Avx = nameof(System.Runtime.Intrinsics.X86.Avx);
-        public const string Sse3 = nameof(System.Runtime.Intrinsics.X86.Sse3);
-        public const string Sse2 = nameof(System.Runtime.Intrinsics.X86.Sse2);
-        
-        // Arm
-        public const string AdvSimd = nameof(System.Runtime.Intrinsics.Arm.AdvSimd);
-        
-        /// <summary>
-        /// This applies capability-based exclusions as filters to the config.
-        /// </summary>
-        /// <param name="self">a Benchmark Config, e.g. as used in Program.cs</param>
-        public static IConfig WithCapabilityExclusions(this IConfig self)
-        {
-            if (!System.Runtime.Intrinsics.X86.Avx2.IsSupported)
-            {
-                self = self.AddFilter(new CategoryExclusion(Avx2));
-            }
-
-            if (!System.Runtime.Intrinsics.X86.Avx.IsSupported)
-            {
-                self = self.AddFilter(new CategoryExclusion(Avx));
-            }
-
-            if (!System.Runtime.Intrinsics.X86.Sse3.IsSupported)
-            {
-                self = self.AddFilter(new CategoryExclusion(Sse3));
-            }
-
-            if (!System.Runtime.Intrinsics.X86.Sse2.IsSupported)
-            {
-                self = self.AddFilter(new CategoryExclusion(Sse2));
-            }
-
-            if (!System.Runtime.Intrinsics.Arm.AdvSimd.IsSupported)
-            {
-                self = self.AddFilter(new CategoryExclusion(AdvSimd));
-            }
-
-            return self;
-        }
-    }
-    
     /// <summary>
     /// Excludes a given category from benchmarks.
     /// (used by Program.cs)

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -40,11 +40,13 @@ namespace Ecs.CSharp.Benchmark.Contexts
 
     internal class FennecsBaseContext(int entityCount) : IDisposable
     {
-        public World World { get; } = new(entityCount * 2);
+        public World World { get; } = new World(entityCount * 2);
 
         public virtual void Dispose()
         {
             World.Dispose();
         }
+        public FennecsBaseContext() : this(100000)
+        { }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 using fennecs;
 
 namespace Ecs.CSharp.Benchmark.Contexts
@@ -7,16 +8,32 @@ namespace Ecs.CSharp.Benchmark.Contexts
     {
         internal struct Component1
         {
+            public static implicit operator Component1(int value) => new() { Value = value }; 
+            public static implicit operator Component2(Component1 self) => new() { Value = self.Value }; 
+            public static implicit operator Component3(Component1 self) => new() { Value = self.Value }; 
+            public static implicit operator int (Component1 c) => c.Value;
+            
             public int Value;
         }
 
         internal struct Component2
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static implicit operator Component1(Component2 self) => new() { Value = self.Value }; 
+            public static implicit operator Component2(int value) => new() { Value = value }; 
+            public static implicit operator Component3(Component2 self) => new() { Value = self.Value }; 
+            public static implicit operator int (Component2 c) => c.Value;
+            
             public int Value;
         }
 
         internal struct Component3
         {
+            public static implicit operator Component1(Component3 self) => new() { Value = self.Value }; 
+            public static implicit operator Component2(Component3 self) => new() { Value = self.Value }; 
+            public static implicit operator Component3(int value) => new() { Value = value }; 
+            public static implicit operator int (Component3 c) => c.Value;
+            
             public int Value;
         }
     }

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -6,7 +6,7 @@ namespace Ecs.CSharp.Benchmark.Contexts
 {
     namespace Fennecs_Components
     {
-        internal struct Component1
+        internal record struct Component1
         {
             public static implicit operator Component1(int value) => new() { Value = value }; 
             public static implicit operator Component2(Component1 self) => new() { Value = self.Value }; 
@@ -16,7 +16,7 @@ namespace Ecs.CSharp.Benchmark.Contexts
             public int Value;
         }
 
-        internal struct Component2
+        internal record  struct Component2
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static implicit operator Component1(Component2 self) => new() { Value = self.Value }; 
@@ -27,7 +27,7 @@ namespace Ecs.CSharp.Benchmark.Contexts
             public int Value;
         }
 
-        internal struct Component3
+        internal record struct Component3
         {
             public static implicit operator Component1(Component3 self) => new() { Value = self.Value }; 
             public static implicit operator Component2(Component3 self) => new() { Value = self.Value }; 

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -25,7 +25,7 @@ namespace Ecs.CSharp.Benchmark.Contexts
     {
         public World World { get; } = new(entityCount * 2);
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             World.Dispose();
         }

--- a/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FennecsBaseContext.cs
@@ -21,14 +21,9 @@ namespace Ecs.CSharp.Benchmark.Contexts
         }
     }
 
-    internal class FennecsBaseContext : IDisposable
+    internal class FennecsBaseContext(int entityCount) : IDisposable
     {
-        public World World { get; }
-
-        public FennecsBaseContext()
-        {
-            World = new World();
-        }
+        public World World { get; } = new(entityCount * 2);
 
         public void Dispose()
         {

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
@@ -8,7 +8,7 @@ namespace Ecs.CSharp.Benchmark
     public partial class CreateEntityWithOneComponent
     {
         [Context] private readonly FennecsBaseContext _fennecs;
-
+        
         [BenchmarkCategory(Categories.Fennecs)]
         [Benchmark]
         public void Fennecs()

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Fennecs.cs
@@ -10,15 +10,14 @@ namespace Ecs.CSharp.Benchmark
         [Context] private readonly FennecsBaseContext _fennecs;
         
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
+        [Benchmark(Description = "fennecs")]
         public void Fennecs()
         {
             World world = _fennecs.World;
 
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                world.Spawn().Add<Component1>();
-            }
+            world.Entity()
+                .Add(new Component1())
+                .Spawn(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
@@ -3,6 +3,7 @@ using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
 using fennecs;
 
+// ReSharper disable once CheckNamespace
 namespace Ecs.CSharp.Benchmark
 {
     public partial class CreateEntityWithThreeComponents

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
@@ -8,9 +8,8 @@ namespace Ecs.CSharp.Benchmark
 {
     public partial class CreateEntityWithThreeComponents
     {
-        [Context]
-        private readonly FennecsBaseContext _fennecs;
-
+        [Context] private readonly FennecsBaseContext _fennecs;
+        
         [BenchmarkCategory(Categories.Fennecs)]
         [Benchmark]
         public void Fennecs()

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Fennecs.cs
@@ -11,18 +11,16 @@ namespace Ecs.CSharp.Benchmark
         [Context] private readonly FennecsBaseContext _fennecs;
         
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
+        [Benchmark(Description = "fennecs")]
         public void Fennecs()
         {
             World world = _fennecs.World;
 
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                world.Spawn()
-                    .Add<Component1>()
-                    .Add<Component2>()
-                    .Add<Component3>();
-            }
+            world.Entity()
+                .Add(new Component1())
+                .Add(new Component2())
+                .Add(new Component3())
+                .Spawn(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
@@ -8,7 +8,7 @@ namespace Ecs.CSharp.Benchmark
     public partial class CreateEntityWithTwoComponents
     {
         [Context] private readonly FennecsBaseContext _fennecs;
-
+        
         [BenchmarkCategory(Categories.Fennecs)]
         [Benchmark]
         public void Fennecs()

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Fennecs.cs
@@ -10,16 +10,15 @@ namespace Ecs.CSharp.Benchmark
         [Context] private readonly FennecsBaseContext _fennecs;
         
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
+        [Benchmark(Description = "fennecs")]
         public void Fennecs()
         {
             World world = _fennecs.World;
 
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                world.Spawn().
-                    Add<Component1>().Add<Component2>();
-            }
+            world.Entity()
+                .Add(new Component1())
+                .Add(new Component2())
+                .Spawn(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
-    <PackageReference Include="fennecs" Version="0.3.5-beta" />
+    <PackageReference Include="fennecs" Version="0.4.0-beta" />
     
     <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
 

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
-    <PackageReference Include="fennecs" Version="0.4.0-beta" />
+    <PackageReference Include="fennecs" Version="0.5.4-beta" />
     
     <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
 

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
-    <PackageReference Include="fennecs" Version="0.1.1-beta" />
+    <PackageReference Include="fennecs" Version="0.3.5-beta" />
     
     <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
 

--- a/source/Ecs.CSharp.Benchmark/Program.cs
+++ b/source/Ecs.CSharp.Benchmark/Program.cs
@@ -14,20 +14,22 @@ CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
 
 BenchmarkSwitcher benchmark = BenchmarkSwitcher.FromTypes(new[]
 {
-    typeof(CreateEntityWithOneComponent),
-    typeof(CreateEntityWithTwoComponents),
-    typeof(CreateEntityWithThreeComponents),
-
     typeof(SystemWithOneComponent),
     typeof(SystemWithTwoComponents),
     typeof(SystemWithThreeComponents),
 
-    typeof(SystemWithTwoComponentsMultipleComposition)
+    typeof(SystemWithTwoComponentsMultipleComposition),
+
+    //Moving lighter tests to the back makes the estimated time display more reliable 
+    typeof(CreateEntityWithOneComponent),
+    typeof(CreateEntityWithTwoComponents),
+    typeof(CreateEntityWithThreeComponents),
 });
 
-IConfig configuration = DefaultConfig.Instance.WithOptions(ConfigOptions.DisableOptimizationsValidator);
 
-Capabilities.ApplyExclusions(configuration);
+IConfig configuration = DefaultConfig.Instance
+    .WithOptions(ConfigOptions.DisableOptimizationsValidator)
+    .WithCapabilityExclusions();
 
 if (args.Length > 0)
 {

--- a/source/Ecs.CSharp.Benchmark/Program.cs
+++ b/source/Ecs.CSharp.Benchmark/Program.cs
@@ -1,10 +1,7 @@
 ﻿#pragma warning disable CA1852 // Seal internal types
 
-using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
 using BenchmarkDotNet.Configs;
-using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Running;
 using Ecs.CSharp.Benchmark;
 
@@ -34,17 +31,12 @@ IConfig configuration = DefaultConfig.Instance
     .WithOptions(ConfigOptions.DisableOptimizationsValidator)
     .WithCapabilityExclusions();
 
+#if RANK_RESULTS
+    configuration = configuration.WithOrderer(new BenchmarkDotNet.Order.DefaultOrderer(BenchmarkDotNet.Order.SummaryOrderPolicy.FastestToSlowest));
+#endif
+
 if (args.Length > 0)
 {
-    // There's no orderer commandline arg, so let's pretend there is one.
-    if (args.Contains("--ranking"))
-    {
-        List<string> argList = args.ToList();
-        argList.Remove("--ranking");
-        args = argList.ToArray();
-        configuration = configuration.WithOrderer(new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest));
-    }
-
     benchmark.Run(args, configuration);
 }
 else

--- a/source/Ecs.CSharp.Benchmark/Program.cs
+++ b/source/Ecs.CSharp.Benchmark/Program.cs
@@ -1,7 +1,10 @@
 ﻿#pragma warning disable CA1852 // Seal internal types
 
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Running;
 using Ecs.CSharp.Benchmark;
 
@@ -33,6 +36,15 @@ IConfig configuration = DefaultConfig.Instance
 
 if (args.Length > 0)
 {
+    // There's no orderer commandline arg, so let's pretend there is one.
+    if (args.Contains("--ranking"))
+    {
+        List<string> argList = args.ToList();
+        argList.Remove("--ranking");
+        args = argList.ToArray();
+        configuration = configuration.WithOrderer(new DefaultOrderer(SummaryOrderPolicy.FastestToSlowest));
+    }
+
     benchmark.Run(args, configuration);
 }
 else

--- a/source/Ecs.CSharp.Benchmark/Program.cs
+++ b/source/Ecs.CSharp.Benchmark/Program.cs
@@ -27,6 +27,8 @@ BenchmarkSwitcher benchmark = BenchmarkSwitcher.FromTypes(new[]
 
 IConfig configuration = DefaultConfig.Instance.WithOptions(ConfigOptions.DisableOptimizationsValidator);
 
+Capabilities.ApplyExclusions(configuration);
+
 if (args.Length > 0)
 {
     benchmark.Run(args, configuration);

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -104,7 +104,7 @@ namespace Ecs.CSharp.Benchmark
         #region Raw Runners
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        [Benchmark(Description = "fennecs (AVX2)")]
         public void Fennecs_Raw_AVX2()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)
@@ -134,7 +134,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        [Benchmark(Description = "fennecs (SSE2)")]
         public void Fennecs_Raw_SSE2()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)
@@ -164,7 +164,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        [Benchmark(Description = "fennecs (AdvSIMD)")]
         public void Fennecs_Raw_AdvSimd()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -80,8 +80,8 @@ namespace Ecs.CSharp.Benchmark
             _fennecs.query.Job(static (ref Component1 v) => { v.Value++; });
         }
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (Blit)")]
+        //[BenchmarkCategory(Categories.Fennecs)]
+        //[Benchmark(Description = "fennecs (Blit)")]
         public void Fennecs_Raw_Blit()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -18,11 +18,11 @@ namespace Ecs.CSharp.Benchmark
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            public readonly Query<Component1> query;
+            public readonly Stream<Component1> query;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1>().Compile();
+                query = World.Stream<Component1>();
                 for (int i = 0; i < entityCount; ++i)
                 {
                     for (int j = 0; j < entityPadding; ++j)
@@ -33,8 +33,7 @@ namespace Ecs.CSharp.Benchmark
                     World.Spawn().Add<Component1>();
                 }
 
-                query.Warmup();
-                query.Batch(Batch.AddConflict.Replace)
+                query.Query.Batch(Batch.AddConflict.Replace)
                     .Add(new Component1
                     {
                         Value = 0
@@ -44,7 +43,7 @@ namespace Ecs.CSharp.Benchmark
 
             public override void Dispose()
             {
-                query.Dispose();
+                query.Query.Dispose();
                 base.Dispose();
             }
         }
@@ -57,20 +56,13 @@ namespace Ecs.CSharp.Benchmark
         }
 
         // Disabled for now.
-        // This API is available in fennecs 0.3.x, but is not optimized yet.
+        // This API is available in fennecs 0.3.x and later, but is not optimized yet.
         //[BenchmarkCategory(Categories.Fennecs)]
         //[Benchmark (Description = "fennecs(Batch)")]
         public void Fennecs_Batch()
         {
-            int newValue = _fennecs.query[0].Ref<Component1>().Value + 1;
-            
-            _fennecs.query
-                .Batch(Batch.AddConflict.Replace)
-                .Add(new Component1
-                {
-                    Value = newValue
-                })
-                .Submit();
+            int newValue = _fennecs.query.Query[0].Ref<Component1>().Value + 1;
+            _fennecs.query.Blit(newValue);
         }
 
         [BenchmarkCategory(Categories.Fennecs)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -22,7 +22,7 @@ namespace Ecs.CSharp.Benchmark
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1>().Build();
+                query = World.Query<Component1>().Compile();
                 for (int i = 0; i < entityCount; ++i)
                 {
                     for (int j = 0; j < entityPadding; ++j)

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -1,19 +1,24 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
+using System.Buffers;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
 using fennecs;
 
+// ReSharper disable once CheckNamespace
 namespace Ecs.CSharp.Benchmark
 {
     public partial class SystemWithOneComponent
     {
         [Context] private readonly FennecsContext _fennecs;
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            public Query<Component1> query;
+            public readonly Query<Component1> query;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
@@ -27,6 +32,11 @@ namespace Ecs.CSharp.Benchmark
 
                     World.Spawn().Add<Component1>();
                 }
+
+                query.Warmup();
+                query.Batch(Batch.AddConflict.Replace)
+                    .Add(new Component1 { Value = 0 })
+                    .Submit();
             }
         }
 
@@ -34,7 +44,19 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void Fennecs_ForEach()
         {
-            _fennecs.query.For((ref Component1 comp0) => comp0.Value++);
+            _fennecs.query.For(delegate(ref Component1 v) { v.Value++; });
+        }
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark]
+        public void Fennecs_Batch()
+        {
+            int newValue = _fennecs.query[0].Ref<Component1>().Value + 1;
+            
+            _fennecs.query
+                .Batch(Batch.AddConflict.Replace)
+                .Add(new Component1 { Value = newValue })
+                .Submit();
         }
 
         [BenchmarkCategory(Categories.Fennecs)]
@@ -56,5 +78,114 @@ namespace Ecs.CSharp.Benchmark
                 }
             });
         }
+        
+        #region Raw Runners
+        
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
+        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        public void Fennecs_Raw_AVX2()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> mem1)
+            {
+                int count = mem1.Length;
+                
+                using MemoryHandle handle1 = mem1.Pin();
+
+                unsafe
+                {
+                    int* p1 = (int*)handle1.Pointer;
+
+                    int vectorSize = Vector256<int>.Count;
+                    int vectorEnd = count - (count % vectorSize);
+                    for (int i = 0; i < vectorEnd; i += vectorSize)
+                    {
+                        Vector256<int> v1 = Avx.LoadVector256(p1 + i);
+                        Avx.Store(p1 + i, Avx2.Add(v1, Vector256<int>.One));
+                    }
+
+                    for (int i = vectorEnd; i < count; i++) // remaining elements
+                    {
+                        p1[i]++;
+                    }
+                }
+            });
+        }
+        
+        
+        
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (Raw Blit)")]
+        public void Fennecs_Raw_Blit()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> mem1)
+            {
+                Component1 newValue = mem1.Span[0];
+                newValue.Value++;
+                
+                mem1.Span.Fill(newValue);
+            });
+        }
+        
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
+        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        public void Fennecs_Raw_SSE2()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> mem1)
+            {
+                int count = mem1.Length;
+                
+                using MemoryHandle handle1 = mem1.Pin();
+
+                unsafe
+                {
+                    int* p1 = (int*)handle1.Pointer;
+
+                    int vectorSize = Vector128<int>.Count;
+                    int vectorEnd = count - (count % vectorSize);
+                    for (int i = 0; i < vectorEnd; i += vectorSize)
+                    {
+                        Vector128<int> v1 = Sse2.LoadVector128(p1 + i);
+                        Sse2.Store(p1 + i, Sse2.Add(v1, Vector128<int>.One));
+                    }
+
+                    for (int i = vectorEnd; i < count; i++) // remaining elements
+                    {
+                        p1[i]++;
+                    }
+                }
+            });
+        }
+        
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
+        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        public void Fennecs_Raw_AdvSimd()
+        {
+            _fennecs.query.Raw(delegate(Memory<Component1> mem1)
+            {
+                int count = mem1.Length;
+                
+                using MemoryHandle handle1 = mem1.Pin();
+
+                unsafe
+                {
+                    int* p1 = (int*)handle1.Pointer;
+
+                    int vectorSize = Vector128<int>.Count;
+                    int vectorEnd = count - (count % vectorSize);
+                    for (int i = 0; i < vectorEnd; i += vectorSize)
+                    {
+                        Vector128<int> v1 = AdvSimd.LoadVector128(p1 + i);
+                        AdvSimd.Store(p1 + i, AdvSimd.Add(v1, Vector128<int>.One));
+                    }
+
+                    for (int i = vectorEnd; i < count; i++) // remaining elements
+                    {
+                        p1[i]++;
+                    }
+                }
+            });
+        }
+        
+        #endregion
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -50,7 +50,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark (Description = "fennecs (For)")]
+        [Benchmark (Description = "fennecs(For)")]
         public void Fennecs_For()
         {
             _fennecs.query.For(static (ref Component1 v) => { v.Value++; });
@@ -59,7 +59,7 @@ namespace Ecs.CSharp.Benchmark
         // Disabled for now.
         // This API is available in fennecs 0.3.x, but is not optimized yet.
         //[BenchmarkCategory(Categories.Fennecs)]
-        //[Benchmark (Description = "fennecs (Batch)")]
+        //[Benchmark (Description = "fennecs(Batch)")]
         public void Fennecs_Batch()
         {
             int newValue = _fennecs.query[0].Ref<Component1>().Value + 1;
@@ -74,14 +74,14 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark (Description = "fennecs (Job)")]
+        [Benchmark (Description = "fennecs(Job)")]
         public void Fennecs_Job()
         {
             _fennecs.query.Job(static (ref Component1 v) => { v.Value++; });
         }
 
         //[BenchmarkCategory(Categories.Fennecs)]
-        //[Benchmark(Description = "fennecs (Blit)")]
+        //[Benchmark(Description = "fennecs(Blit)")]
         public void Fennecs_Raw_Blit()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)
@@ -104,7 +104,7 @@ namespace Ecs.CSharp.Benchmark
         #region Raw Runners
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (AVX2)")]
+        [Benchmark(Description = "fennecs(AVX2)")]
         public void Fennecs_Raw_AVX2()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)
@@ -134,7 +134,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (SSE2)")]
+        [Benchmark(Description = "fennecs(SSE2)")]
         public void Fennecs_Raw_SSE2()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)
@@ -164,7 +164,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (AdvSIMD)")]
+        [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void Fennecs_Raw_AdvSimd()
         {
             _fennecs.query.Raw(delegate(Memory<Component1> mem1)

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Fennecs.cs
@@ -15,7 +15,7 @@ namespace Ecs.CSharp.Benchmark
         {
             public Query<Component1> query;
 
-            public FennecsContext(int entityCount, int entityPadding)
+            public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
                 query = World.Query<Component1>().Build();
                 for (int i = 0; i < entityCount; ++i)
@@ -41,7 +41,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void Fennecs_Job()
         {
-            _fennecs.query.Job(delegate(ref Component1 v) { v.Value++; }, 1024);
+            _fennecs.query.Job(delegate(ref Component1 v) { v.Value++; });
         }
         
         [BenchmarkCategory(Categories.Fennecs)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/_SystemWithOneComponent.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/_SystemWithOneComponent.cs
@@ -2,7 +2,7 @@
 
 namespace Ecs.CSharp.Benchmark
 {
-    [BenchmarkCategory(Categories.System)]
+    [BenchmarkCategory(Categories.System, nameof(SystemWithOneComponent))]
     [MemoryDiagnoser]
 #if CHECK_CACHE_MISSES
     [HardwareCounters(BenchmarkDotNet.Diagnosers.HardwareCounter.CacheMisses)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -14,12 +14,12 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithThreeComponents
     {
         [Context] private readonly FennecsContext _fennecs;
-        private Stream<Component1, Component2, Component3> Query => _fennecs.query;
+        private Stream<Component1, Component2, Component3> Stream => _fennecs.stream;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            internal readonly Stream<Component1, Component2, Component3> query;
+            internal readonly Stream<Component1, Component2, Component3> stream;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
@@ -47,12 +47,12 @@ namespace Ecs.CSharp.Benchmark
                         .Add(new Component3 {Value = 1});
                 }
 
-                query = World.Query<Component1, Component2, Component3>().Stream();
+                stream = World.Query<Component1, Component2, Component3>().Stream();
             }
             
             public override void Dispose()
             {
-                query.Query.Dispose();
+                stream.Query.Dispose();
                 base.Dispose();
             }
         }
@@ -67,7 +67,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
-            Query.For(
+            Stream.For(
                 static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
                 {
                     c1.Value = c1.Value + c2.Value + c3.Value;
@@ -86,7 +86,7 @@ namespace Ecs.CSharp.Benchmark
         //[Benchmark(Description = "fennecs(Implicit)")]
         public void fennecs_For_Implicit()
         {
-            Query.For(
+            Stream.For(
                 static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
                 {
                     c1 = c1 + c2 + c3;
@@ -111,7 +111,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
-            Query.Job(
+            Stream.Job(
                 static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
                 {
                     c1.Value = c1.Value + c2.Value + c3.Value;
@@ -142,7 +142,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
-            Query.Raw(Raw_Workload_Unoptimized);
+            Stream.Raw(Raw_Workload_Unoptimized);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
-            Query.Raw(Raw_Workload_AVX2);
+            Stream.Raw(Raw_Workload_AVX2);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
-            Query.Raw(Raw_Workload_SSE2);
+            Stream.Raw(Raw_Workload_SSE2);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
-            Query.Raw(Raw_Workload_AdvSIMD);
+            Stream.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -1,5 +1,8 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
+using System.Buffers;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
@@ -10,14 +13,17 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithThreeComponents
     {
         [Context] private readonly FennecsContext _fennecs;
+        private Query<Component1, Component2, Component3> Query => _fennecs.query;
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            public Query<Component1, Component2, Component3> query;
+            internal readonly Query<Component1, Component2, Component3> query;
 
-            public FennecsContext(int entityCount, int entityPadding)
+            public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
                 query = World.Query<Component1, Component2, Component3>().Build();
+
                 for (int i = 0; i < entityCount; ++i)
                 {
                     for (int j = 0; j < entityPadding; ++j)
@@ -38,42 +44,195 @@ namespace Ecs.CSharp.Benchmark
                     }
 
                     World.Spawn().Add<Component1>()
-                        .Add(new Component2 { Value = 1 })
-                        .Add(new Component3 { Value = 1 });
+                        .Add(new Component2 {Value = 1})
+                        .Add(new Component3 {Value = 1});
+                }
+
+                query.Warmup();
+            }
+        }
+
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (For)")]
+        public void fennecs_For()
+        {
+            Query.For(
+                static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
+                {
+                    c1.Value = c1.Value + c2.Value + c3.Value;
+                });
+        }
+
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = $"fennecs (Job)")]
+        public void fennecs_Job()
+        {
+            Query.Job(
+                static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
+                {
+                    c1.Value = c1.Value + c2.Value + c3.Value;
+                });
+        }
+
+
+        #region Raw
+
+        // fennecs guarantees contiguous memory access in the form of Query<>.Raw(MemoryAction<>)
+        // Raw runners are intended to process data or transfer it via the fastest available means,
+        // Example use cases:
+        //  - transfer buffers to/from GPUs or Game Engines
+        //  - Disk, Database, or Network I/O
+        //  - SIMD calculations
+        //  - snapshotting / copying / rollback / compression / decompression / diffing / permutation
+        // As example / reference & benchmark, we vectorized our calculation here using AVX2, SSE2, and AdvSIMD
+
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (Raw)")]
+        public void fennecs_Raw()
+        {
+            Query.Raw(Raw_Workload_Unoptimized);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
+        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        public void fennecs_Raw_AVX2()
+        {
+            Query.Raw(Raw_Workload_AVX2);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
+        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        public void fennecs_Raw_SSE2()
+        {
+            Query.Raw(Raw_Workload_SSE2);
+        }
+
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
+        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        public void fennecs_Raw_AdvSIMD()
+        {
+            Query.Raw(Raw_Workload_AdvSIMD);
+        }
+
+        #region Workloads
+
+        private static void Raw_Workload_Unoptimized(Memory<Component1> c1V, Memory<Component2> c2V, Memory<Component3> c3V)
+        {
+            Span<Component1> c1S = c1V.Span;
+            Span<Component2> c2S = c2V.Span;
+            Span<Component3> c3S = c3V.Span;
+
+            for (int i = 0; i < c1S.Length; i++)
+            {
+                c1S[i].Value = c1S[i].Value + c2S[i].Value + c3S[i].Value;
+            }
+        }
+
+        private static void Raw_Workload_AVX2(Memory<Component1> c1V, Memory<Component2> c2V, Memory<Component3> c3V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+            using MemoryHandle mem3 = c3V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+                int* p3 = (int*)mem3.Pointer;
+
+                int vectorSize = Vector256<int>.Count;
+                int vectorEnd = count - count % vectorSize;
+                for (int i = 0; i <= vectorEnd; i += vectorSize)
+                {
+                    Vector256<int> v1 = Avx.LoadVector256(p1 + i);
+                    Vector256<int> v2 = Avx.LoadVector256(p2 + i);
+                    Vector256<int> v3 = Avx.LoadVector256(p3 + i);
+                    Vector256<int> sum = Avx2.Add(v1, Avx2.Add(v2, v3));
+
+                    Avx.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    p1[i] = p1[i] + p2[i] + p3[i];
                 }
             }
         }
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_ForEach()
+        private static void Raw_Workload_SSE2(Memory<Component1> c1V, Memory<Component2> c2V, Memory<Component3> c3V)
         {
-            _fennecs.query.For((ref Component1 c1, ref Component2 c2, ref Component3 c3) => c1.Value += c2.Value + c3.Value);
-        }
+            (int Item1, int Item2) range = (0, c1V.Length);
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Job()
-        {
-            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2, ref Component3 c3) { c1.Value += c2.Value + c3.Value; }, 1024);
-        }
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+            using MemoryHandle mem3 = c3V.Pin();
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Raw()
-        {
-            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v, Memory<Component3> c3v)
+            unsafe
             {
-                var c1vs = c1v.Span;
-                var c2vs = c2v.Span;
-                var c3vs = c3v.Span;
-                
-                for (int i = 0; i < c1vs.Length; ++i)
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+                int* p3 = (int*)mem3.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int i = range.Item1;
+                int vectorEnd = range.Item2 - vectorSize;
+                for (; i <= vectorEnd; i += vectorSize)
                 {
-                    ref Component1 c1 = ref c1vs[i];
-                    c1.Value += c2vs[i].Value + c3vs[i].Value;
+                    Vector128<int> v1 = Sse2.LoadVector128(p1 + i);
+                    Vector128<int> v2 = Sse2.LoadVector128(p2 + i);
+                    Vector128<int> v3 = Sse2.LoadVector128(p3 + i);
+                    Vector128<int> sum = Sse2.Add(v1, Sse2.Add(v2, v3));
+
+                    Sse2.Store(p1 + i, sum);
                 }
-            });
+
+                for (; i < range.Item2; i++) // remaining elements
+                {
+                    p1[i] = p1[i] + p2[i] + p3[i];
+                }
+            }
         }
+
+        private static void Raw_Workload_AdvSIMD(Memory<Component1> c1V, Memory<Component2> c2V, Memory<Component3> c3V)
+        {
+            (int Item1, int Item2) range = (0, c1V.Length);
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+            using MemoryHandle mem3 = c3V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+                int* p3 = (int*)mem3.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int i = range.Item1;
+                int vectorEnd = range.Item2 - vectorSize;
+                for (; i <= vectorEnd; i += vectorSize)
+                {
+                    Vector128<int> v1 = AdvSimd.LoadVector128(p1 + i);
+                    Vector128<int> v2 = AdvSimd.LoadVector128(p2 + i);
+                    Vector128<int> v3 = AdvSimd.LoadVector128(p3 + i);
+                    Vector128<int> sum = AdvSimd.Add(v1, AdvSimd.Add(v2, v3));
+
+                    AdvSimd.Store(p1 + i, sum);
+                }
+
+                for (; i < range.Item2; i++) // remaining elements
+                {
+                    p1[i] = p1[i] + p2[i] + p3[i];
+                }
+            }
+        }
+        #endregion
+        
+        #endregion
     }
 }
+#pragma warning restore IDE0008

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -23,8 +23,6 @@ namespace Ecs.CSharp.Benchmark
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1, Component2, Component3>().Build();
-
                 for (int i = 0; i < entityCount; ++i)
                 {
                     for (int j = 0; j < entityPadding; ++j)
@@ -49,7 +47,7 @@ namespace Ecs.CSharp.Benchmark
                         .Add(new Component3 {Value = 1});
                 }
 
-                query.Warmup();
+                query = World.Query<Component1, Component2, Component3>().Build().Warmup();
             }
             
             public override void Dispose()
@@ -73,6 +71,25 @@ namespace Ecs.CSharp.Benchmark
                 static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
                 {
                     c1.Value = c1.Value + c2.Value + c3.Value;
+                });
+        }
+
+
+        /// <summary>
+        /// Experimental Implicit value type to compare performance in a tight loop.
+        /// </summary>
+        /// <remarks>
+        /// It's very convenient, but is about 20% slower than the For runner with values
+        /// (it still gets inlined well!)
+        /// </remarks>
+        //[BenchmarkCategory(Categories.Fennecs)]
+        //[Benchmark(Description = "fennecs (Implicit)")]
+        public void fennecs_For_Implicit()
+        {
+            Query.For(
+                static (ref Component1 c1, ref Component2 c2, ref Component3 c3) =>
+                {
+                    c1 = c1 + c2 + c3;
                 });
         }
 
@@ -184,8 +201,7 @@ namespace Ecs.CSharp.Benchmark
 
             for (int i = 0; i < c1S.Length; i++)
             {
-                ref Component1 output = ref c1S[i]; 
-                output.Value = output.Value + c2S[i].Value + c3S[i].Value;
+                c1S[i].Value = c1S[i].Value + c2S[i].Value + c3S[i].Value;
             }
         }
 

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -152,7 +152,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        [Benchmark(Description = "fennecs (AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -165,7 +165,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        [Benchmark(Description = "fennecs (SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -178,7 +178,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        [Benchmark(Description = "fennecs (AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -64,7 +64,7 @@ namespace Ecs.CSharp.Benchmark
         /// They are the most versatile and offer decent single-threaded baseline performance to boot.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (For)")]
+        [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
             Query.For(
@@ -83,7 +83,7 @@ namespace Ecs.CSharp.Benchmark
         /// (it still gets inlined well!)
         /// </remarks>
         //[BenchmarkCategory(Categories.Fennecs)]
-        //[Benchmark(Description = "fennecs (Implicit)")]
+        //[Benchmark(Description = "fennecs(Implicit)")]
         public void fennecs_For_Implicit()
         {
             Query.For(
@@ -108,7 +108,7 @@ namespace Ecs.CSharp.Benchmark
         /// </para>
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = $"fennecs (Job)")]
+        [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
             Query.Job(
@@ -136,10 +136,10 @@ namespace Ecs.CSharp.Benchmark
         #region Raw Runners
         
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// </summary>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (Raw)")]
+        [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
             Query.Raw(Raw_Workload_Unoptimized);
@@ -152,7 +152,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (AVX2)")]
+        [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -165,7 +165,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (SSE2)")]
+        [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -178,14 +178,14 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (AdvSIMD)")]
+        [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// Treating the Memory Slabs basically as Arrays.
         /// </summary>
         /// <remarks>
@@ -206,7 +206,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AVX2 workload for fennecs (Raw)
+        /// AVX2 workload for fennecs(Raw)
         /// We use AVX2 intrinsics to vectorize the workload, executing 8 additions in parallel.
         /// (256 bits)
         /// </summary>
@@ -244,7 +244,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// SSE2 workload for fennecs (Raw)
+        /// SSE2 workload for fennecs(Raw)
         /// We use SSE2 (same as AVX1) intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>
@@ -282,7 +282,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AdvSIMD workload for fennecs (Raw)
+        /// AdvSIMD workload for fennecs(Raw)
         /// We use AdvSIMD intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -14,12 +14,12 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithThreeComponents
     {
         [Context] private readonly FennecsContext _fennecs;
-        private Query<Component1, Component2, Component3> Query => _fennecs.query;
+        private Stream<Component1, Component2, Component3> Query => _fennecs.query;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            internal readonly Query<Component1, Component2, Component3> query;
+            internal readonly Stream<Component1, Component2, Component3> query;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
@@ -47,12 +47,12 @@ namespace Ecs.CSharp.Benchmark
                         .Add(new Component3 {Value = 1});
                 }
 
-                query = World.Query<Component1, Component2, Component3>().Compile().Warmup();
+                query = World.Query<Component1, Component2, Component3>().Stream();
             }
             
             public override void Dispose()
             {
-                query.Dispose();
+                query.Query.Dispose();
                 base.Dispose();
             }
         }

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Fennecs.cs
@@ -47,7 +47,7 @@ namespace Ecs.CSharp.Benchmark
                         .Add(new Component3 {Value = 1});
                 }
 
-                query = World.Query<Component1, Component2, Component3>().Build().Warmup();
+                query = World.Query<Component1, Component2, Component3>().Compile().Warmup();
             }
             
             public override void Dispose()

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/_SystemWithThreeComponents.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/_SystemWithThreeComponents.cs
@@ -2,7 +2,7 @@
 
 namespace Ecs.CSharp.Benchmark
 {
-    [BenchmarkCategory(Categories.System, "3C")]
+    [BenchmarkCategory(Categories.System, nameof(SystemWithThreeComponents))]
     [MemoryDiagnoser]
 #if CHECK_CACHE_MISSES
     [HardwareCounters(BenchmarkDotNet.Diagnosers.HardwareCounter.CacheMisses)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/_SystemWithThreeComponents.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/_SystemWithThreeComponents.cs
@@ -2,7 +2,7 @@
 
 namespace Ecs.CSharp.Benchmark
 {
-    [BenchmarkCategory(Categories.System)]
+    [BenchmarkCategory(Categories.System, "3C")]
     [MemoryDiagnoser]
 #if CHECK_CACHE_MISSES
     [HardwareCounters(BenchmarkDotNet.Diagnosers.HardwareCounter.CacheMisses)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -24,7 +24,7 @@ namespace Ecs.CSharp.Benchmark
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1, Component2>().Build();
+                query = World.Query<Component1, Component2>().Compile();
 
                 for (int i = 0; i < entityCount; ++i)
                 {

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -7,6 +7,7 @@ using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
 using fennecs;
+// ReSharper disable ConvertToCompoundAssignment
 
 // ReSharper disable once CheckNamespace
 namespace Ecs.CSharp.Benchmark

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -15,16 +15,16 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithTwoComponents
     {
         [Context] private readonly FennecsContext _fennecs;
-        private Query<Component1, Component2> Query => _fennecs.query;
+        private Stream<Component1, Component2> Query => _fennecs.query;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            internal readonly Query<Component1, Component2> query;
+            internal readonly Stream<Component1, Component2> query;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1, Component2>().Compile();
+                query = World.Query<Component1, Component2>().Stream();
 
                 for (int i = 0; i < entityCount; ++i)
                 {
@@ -49,12 +49,11 @@ namespace Ecs.CSharp.Benchmark
                         });
                 }
 
-                query.Warmup();
             }
             
             public override void Dispose()
             {
-                query.Dispose();
+                query.Query.Dispose();
                 base.Dispose();
             }
         }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -135,7 +135,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        [Benchmark(Description = "fennecs (AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -148,7 +148,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        [Benchmark(Description = "fennecs (SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -161,7 +161,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        [Benchmark(Description = "fennecs (AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -15,16 +15,16 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithTwoComponents
     {
         [Context] private readonly FennecsContext _fennecs;
-        private Stream<Component1, Component2> Query => _fennecs.query;
+        private Stream<Component1, Component2> Stream => _fennecs.stream;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            internal readonly Stream<Component1, Component2> query;
+            internal readonly Stream<Component1, Component2> stream;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
-                query = World.Query<Component1, Component2>().Stream();
+                stream = World.Query<Component1, Component2>().Stream();
 
                 for (int i = 0; i < entityCount; ++i)
                 {
@@ -53,7 +53,7 @@ namespace Ecs.CSharp.Benchmark
             
             public override void Dispose()
             {
-                query.Query.Dispose();
+                stream.Query.Dispose();
                 base.Dispose();
             }
         }
@@ -68,7 +68,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
-            Query.For(
+            Stream.For(
                 static (ref Component1 c1, ref Component2 c2) =>
                 {
                     c1.Value = c1.Value + c2.Value;
@@ -93,7 +93,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
-            Query.Job(
+            Stream.Job(
                 static (ref Component1 c1, ref Component2 c2) =>
                 {
                     c1.Value = c1.Value + c2.Value;
@@ -124,7 +124,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
-            Query.Raw(Raw_Workload_Unoptimized);
+            Stream.Raw(Raw_Workload_Unoptimized);
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
-            Query.Raw(Raw_Workload_AVX2);
+            Stream.Raw(Raw_Workload_AVX2);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
-            Query.Raw(Raw_Workload_SSE2);
+            Stream.Raw(Raw_Workload_SSE2);
         }
 
         /// <summary>
@@ -163,7 +163,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
-            Query.Raw(Raw_Workload_AdvSIMD);
+            Stream.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -15,7 +15,7 @@ namespace Ecs.CSharp.Benchmark
         {
             public Query<Component1, Component2> query;
 
-            public FennecsContext(int entityCount, int entityPadding)
+            public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
                 query = World.Query<Component1, Component2>().Build();
                 for (int i = 0; i < entityCount; ++i)
@@ -51,7 +51,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void Fennecs_Job()
         {
-            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; }, 1024);
+            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; });
         }
 
         [BenchmarkCategory(Categories.Fennecs)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -1,73 +1,300 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
+using System.Buffers;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
 using fennecs;
 
+// ReSharper disable once CheckNamespace
 namespace Ecs.CSharp.Benchmark
 {
     public partial class SystemWithTwoComponents
     {
         [Context] private readonly FennecsContext _fennecs;
+        private Query<Component1, Component2> Query => _fennecs.query;
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            public Query<Component1, Component2> query;
+            internal readonly Query<Component1, Component2> query;
 
             public FennecsContext(int entityCount, int entityPadding) : base(entityCount)
             {
                 query = World.Query<Component1, Component2>().Build();
+
                 for (int i = 0; i < entityCount; ++i)
                 {
                     for (int j = 0; j < entityPadding; ++j)
                     {
                         Entity padding = World.Spawn();
-                        switch (j % 2)
+                        switch (j % 3)
                         {
                             case 0:
                                 padding.Add<Component1>();
                                 break;
-
                             case 1:
                                 padding.Add<Component2>();
                                 break;
                         }
                     }
 
-                    World.Spawn().Add<Component1>().Add(new Component2 { Value = 1 });
+                    World.Spawn().Add<Component1>()
+                        .Add(new Component2
+                        {
+                            Value = 1
+                        });
+                }
+
+                query.Warmup();
+            }
+            
+            public override void Dispose()
+            {
+                query.Dispose();
+                base.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// fennecs For runners are the classic swiss army knife of this ECS. 
+        /// </summary>
+        /// <remarks>
+        /// They are the most versatile and offer decent single-threaded baseline performance to boot.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (For)")]
+        public void fennecs_For()
+        {
+            Query.For(
+                static (ref Component1 c1, ref Component2 c2) =>
+                {
+                    c1.Value = c1.Value + c2.Value;
+                });
+        }
+
+
+        /// <summary>
+        /// fennecs Job runners are the most scalable runners.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// They're still an area for improvement :)
+        /// </para>
+        /// <para>
+        /// Job is designed for heavy individual workloads (e.g. update 20 physics worlds on 20 cores),
+        /// or large numbers of entities in many big archetypes. They only start paying off at around
+        /// 500,000 components when the individual work steps are simple (e.g. vector multiplications).
+        /// </para>
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = $"fennecs (Job)")]
+        public void fennecs_Job()
+        {
+            Query.Job(
+                static (ref Component1 c1, ref Component2 c2) =>
+                {
+                    c1.Value = c1.Value + c2.Value;
+                });
+        }
+
+
+        // fennecs Raw runners guarantee contiguous memory access in the form of Query<>.Raw(MemoryAction<>)
+        // Raw runners are intended to process data or transfer it via the fastest available means.
+        // Example use cases:
+        //  - transfer data to/from GPU
+        //  - transfer data to/from Game Engine
+        //  - Disk, Database, or Network I/O
+        //  - SIMD calculations
+        //  - snapshotting / copying / rollback / compression / hashing / diffing / permutation
+        //  - etc.
+        //
+        // As example / reference / benchmarks, we vectorize our calculation here using AVX2, SSE2, and AdvSIMD
+        // Despite the 'unsafe' tags, this is quite safe ;) The Memory<T>s are pinned till end of scope.
+        // We also keep an Unoptimized Workload around to let RyuJIT show off its magic. (still good!)
+
+        #region Raw Runners
+        
+        /// <summary>
+        /// Unoptimized workload for fennecs (Raw)
+        /// </summary>
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (Raw)")]
+        public void fennecs_Raw()
+        {
+            Query.Raw(Raw_Workload_Unoptimized);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (AVX2)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support AVX2.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
+        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        public void fennecs_Raw_AVX2()
+        {
+            Query.Raw(Raw_Workload_AVX2);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (SSE2 / AVX1)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support SSE2.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
+        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        public void fennecs_Raw_SSE2()
+        {
+            Query.Raw(Raw_Workload_SSE2);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (Arm64 AdvSIMD)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
+        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        public void fennecs_Raw_AdvSIMD()
+        {
+            Query.Raw(Raw_Workload_AdvSIMD);
+        }
+
+        /// <summary>
+        /// Unoptimized workload for fennecs (Raw)
+        /// Treating the Memory Slabs basically as Arrays.
+        /// </summary>
+        /// <remarks>
+        /// However, RyuJIT is able to optimize this workload to a degree,
+        /// especially if we use an explicit assignment instead of a compound assignment
+        /// for our addition. 
+        /// </remarks>
+        private static void Raw_Workload_Unoptimized(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            Span<Component1> c1S = c1V.Span;
+            Span<Component2> c2S = c2V.Span;
+
+            for (int i = 0; i < c1S.Length; i++)
+            {
+                // Compound Assignment is not as optimized as explicit assignment
+                c1S[i].Value = c1S[i].Value + c2S[i].Value;
+            }
+        }
+
+        /// <summary>
+        /// AVX2 workload for fennecs (Raw)
+        /// We use AVX2 intrinsics to vectorize the workload, executing 8 additions in parallel.
+        /// (256 bits)
+        /// </summary>
+        private static void Raw_Workload_AVX2(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector256<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
+                {
+                    Vector256<int> v1 = Avx.LoadVector256(p1 + i);
+                    Vector256<int> v2 = Avx.LoadVector256(p2 + i);
+                    Vector256<int> sum = Avx2.Add(v1, v2);
+
+                    Avx.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
                 }
             }
         }
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_ForEach()
+        /// <summary>
+        /// SSE2 workload for fennecs (Raw)
+        /// We use SSE2 (same as AVX1) intrinsics to vectorize the workload, executing 4 additions in parallel.
+        /// (128 bits) 
+        /// </summary>
+        private static void Raw_Workload_SSE2(Memory<Component1> c1V, Memory<Component2> c2V)
         {
-            _fennecs.query.For((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
-        }
+            int count = c1V.Length;
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Job()
-        {
-            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; });
-        }
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
 
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Raw()
-        {
-            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v)
+            unsafe
             {
-                var c1vs = c1v.Span;
-                var c2vs = c2v.Span;
-                for (int i = 0; i < c1vs.Length; ++i)
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
                 {
-                    ref Component1 c1 = ref c1vs[i];
-                    c1.Value += c2vs[i].Value;
+                    Vector128<int> v1 = Sse2.LoadVector128(p1 + i);
+                    Vector128<int> v2 = Sse2.LoadVector128(p2 + i);
+                    Vector128<int> sum = Sse2.Add(v1, v2);
+
+                    Sse2.Store(p1 + i, sum);
                 }
-            });
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
+                }
+            }
         }
+
+        /// <summary>
+        /// AdvSIMD workload for fennecs (Raw)
+        /// We use AdvSIMD intrinsics to vectorize the workload, executing 4 additions in parallel.
+        /// (128 bits) 
+        /// </summary>
+        private static void Raw_Workload_AdvSIMD(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
+                {
+                    Vector128<int> v1 = AdvSimd.LoadVector128(p1 + i);
+                    Vector128<int> v2 = AdvSimd.LoadVector128(p2 + i);
+                    Vector128<int> sum = AdvSimd.Add(v1, v2);
+
+                    AdvSimd.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Fennecs.cs
@@ -66,7 +66,7 @@ namespace Ecs.CSharp.Benchmark
         /// They are the most versatile and offer decent single-threaded baseline performance to boot.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (For)")]
+        [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
             Query.For(
@@ -91,7 +91,7 @@ namespace Ecs.CSharp.Benchmark
         /// </para>
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = $"fennecs (Job)")]
+        [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
             Query.Job(
@@ -119,10 +119,10 @@ namespace Ecs.CSharp.Benchmark
         #region Raw Runners
         
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// </summary>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (Raw)")]
+        [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
             Query.Raw(Raw_Workload_Unoptimized);
@@ -135,7 +135,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (AVX2)")]
+        [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -148,7 +148,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (SSE2)")]
+        [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -161,14 +161,14 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (AdvSIMD)")]
+        [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// Treating the Memory Slabs basically as Arrays.
         /// </summary>
         /// <remarks>
@@ -189,7 +189,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AVX2 workload for fennecs (Raw)
+        /// AVX2 workload for fennecs(Raw)
         /// We use AVX2 intrinsics to vectorize the workload, executing 8 additions in parallel.
         /// (256 bits)
         /// </summary>
@@ -225,7 +225,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// SSE2 workload for fennecs (Raw)
+        /// SSE2 workload for fennecs(Raw)
         /// We use SSE2 (same as AVX1) intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>
@@ -261,7 +261,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AdvSIMD workload for fennecs (Raw)
+        /// AdvSIMD workload for fennecs(Raw)
         /// We use AdvSIMD intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/_SystemWithTwoComponents.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/_SystemWithTwoComponents.cs
@@ -2,7 +2,7 @@
 
 namespace Ecs.CSharp.Benchmark
 {
-    [BenchmarkCategory(Categories.System)]
+    [BenchmarkCategory(Categories.System, nameof(SystemWithTwoComponents))]
     [MemoryDiagnoser]
 #if CHECK_CACHE_MISSES
     [HardwareCounters(BenchmarkDotNet.Diagnosers.HardwareCounter.CacheMisses)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -16,7 +16,7 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithTwoComponentsMultipleComposition
     {
         [Context] private readonly FennecsContext _fennecs;
-        private  Stream<Component1, Component2> Query => _fennecs.query;
+        private  Stream<Component1, Component2> Stream => _fennecs.stream;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
@@ -29,7 +29,7 @@ namespace Ecs.CSharp.Benchmark
 
             private struct Padding4;
 
-            public readonly Stream<Component1, Component2> query;
+            public readonly Stream<Component1, Component2> stream;
 
             public FennecsContext(int entityCount) : base(entityCount)
             {
@@ -53,12 +53,12 @@ namespace Ecs.CSharp.Benchmark
                     }
                 }
                 
-                query = World.Query<Component1, Component2>().Stream();
+                stream = World.Query<Component1, Component2>().Stream();
             }
             
             public override void Dispose()
             {
-                query.Query.Dispose();
+                stream.Query.Dispose();
                 base.Dispose();
             }
         }
@@ -73,7 +73,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
-            Query.For(
+            Stream.For(
                 static (ref Component1 c1, ref Component2 c2) =>
                 {
                     c1.Value = c1.Value + c2.Value;
@@ -98,7 +98,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
-            Query.Job(
+            Stream.Job(
                 static (ref Component1 c1, ref Component2 c2) =>
                 {
                     c1.Value = c1.Value + c2.Value;
@@ -129,7 +129,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
-            Query.Raw(Raw_Workload_Unoptimized);
+            Stream.Raw(Raw_Workload_Unoptimized);
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
-            Query.Raw(Raw_Workload_AVX2);
+            Stream.Raw(Raw_Workload_AVX2);
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
-            Query.Raw(Raw_Workload_SSE2);
+            Stream.Raw(Raw_Workload_SSE2);
         }
 
         /// <summary>
@@ -168,7 +168,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
-            Query.Raw(Raw_Workload_AdvSIMD);
+            Stream.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -16,7 +16,7 @@ namespace Ecs.CSharp.Benchmark
     public partial class SystemWithTwoComponentsMultipleComposition
     {
         [Context] private readonly FennecsContext _fennecs;
-        private  Query<Component1, Component2> Query => _fennecs.query;
+        private  Stream<Component1, Component2> Query => _fennecs.query;
 
         // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
@@ -29,7 +29,7 @@ namespace Ecs.CSharp.Benchmark
 
             private struct Padding4;
 
-            public readonly Query<Component1, Component2> query;
+            public readonly Stream<Component1, Component2> query;
 
             public FennecsContext(int entityCount) : base(entityCount)
             {
@@ -53,12 +53,12 @@ namespace Ecs.CSharp.Benchmark
                     }
                 }
                 
-                query = World.Query<Component1, Component2>().Compile().Warmup();
+                query = World.Query<Component1, Component2>().Stream();
             }
             
             public override void Dispose()
             {
-                query.Dispose();
+                query.Query.Dispose();
                 base.Dispose();
             }
         }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -1,30 +1,38 @@
 ﻿using System;
+using System.Buffers;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
 using BenchmarkDotNet.Attributes;
 using Ecs.CSharp.Benchmark.Contexts;
 using Ecs.CSharp.Benchmark.Contexts.Fennecs_Components;
 using fennecs;
 
+// ReSharper disable ConvertToCompoundAssignment
+
+// ReSharper disable once CheckNamespace
 namespace Ecs.CSharp.Benchmark
 {
     public partial class SystemWithTwoComponentsMultipleComposition
     {
         [Context] private readonly FennecsContext _fennecs;
+        private  Query<Component1, Component2> Query => _fennecs.query;
 
+        // ReSharper disable once ClassNeverInstantiated.Local
         private sealed class FennecsContext : FennecsBaseContext
         {
-            private record struct Padding1();
+            private struct Padding1;
 
-            private record struct Padding2();
+            private struct Padding2;
 
-            private record struct Padding3();
+            private struct Padding3;
 
-            private record struct Padding4();
+            private struct Padding4;
 
-            public Query<Component1, Component2> query;
+            public readonly Query<Component1, Component2> query;
 
             public FennecsContext(int entityCount) : base(entityCount)
             {
-                query = World.Query<Component1, Component2>().Build();
                 for (int i = 0; i < entityCount; ++i)
                 {
                     Entity entity = World.Spawn().Add<Component1>().Add(new Component2 { Value = 1 });
@@ -44,37 +52,254 @@ namespace Ecs.CSharp.Benchmark
                             break;
                     }
                 }
+                
+                query = World.Query<Component1, Component2>().Build().Warmup();
+            }
+            
+            public override void Dispose()
+            {
+                query.Dispose();
+                base.Dispose();
             }
         }
 
+        /// <summary>
+        /// fennecs For runners are the classic swiss army knife of this ECS. 
+        /// </summary>
+        /// <remarks>
+        /// They are the most versatile and offer decent single-threaded baseline performance to boot.
+        /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_ForEach()
+        [Benchmark(Description = "fennecs (For)")]
+        public void fennecs_For()
         {
-            _fennecs.query.For((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
-        }
-
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Job()
-        {
-            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; });
-        }
-
-        [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark]
-        public void Fennecs_Raw()
-        {
-            _fennecs.query.Raw(delegate(Memory<Component1> c1v, Memory<Component2> c2v)
-            {
-                var c1vs = c1v.Span;
-                var c2vs = c2v.Span;
-                for (int i = 0; i < c1vs.Length; ++i)
+            Query.For(
+                static (ref Component1 c1, ref Component2 c2) =>
                 {
-                    ref Component1 c1 = ref c1vs[i];
-                    c1.Value += c2vs[i].Value;
-                }
-            });
+                    c1.Value = c1.Value + c2.Value;
+                });
         }
+
+
+        /// <summary>
+        /// fennecs Job runners are the most scalable runners.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// They're still an area for improvement :)
+        /// </para>
+        /// <para>
+        /// Job is designed for heavy individual workloads (e.g. update 20 physics worlds on 20 cores),
+        /// or large numbers of entities in many big archetypes. They only start paying off at around
+        /// 500,000 components when the individual work steps are simple (e.g. vector multiplications).
+        /// </para>
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = $"fennecs (Job)")]
+        public void fennecs_Job()
+        {
+            Query.Job(
+                static (ref Component1 c1, ref Component2 c2) =>
+                {
+                    c1.Value = c1.Value + c2.Value;
+                });
+        }
+
+
+        // fennecs Raw runners guarantee contiguous memory access in the form of Query<>.Raw(MemoryAction<>)
+        // Raw runners are intended to process data or transfer it via the fastest available means.
+        // Example use cases:
+        //  - transfer data to/from GPU
+        //  - transfer data to/from Game Engine
+        //  - Disk, Database, or Network I/O
+        //  - SIMD calculations
+        //  - snapshotting / copying / rollback / compression / hashing / diffing / permutation
+        //  - etc.
+        //
+        // As example / reference / benchmarks, we vectorize our calculation here using AVX2, SSE2, and AdvSIMD
+        // Despite the 'unsafe' tags, this is quite safe ;) The Memory<T>s are pinned till end of scope.
+        // We also keep an Unoptimized Workload around to let RyuJIT show off its magic. (still good!)
+
+        #region Raw Runners
+        
+        /// <summary>
+        /// Unoptimized workload for fennecs (Raw)
+        /// </summary>
+        [BenchmarkCategory(Categories.Fennecs)]
+        [Benchmark(Description = "fennecs (Raw)")]
+        public void fennecs_Raw()
+        {
+            Query.Raw(Raw_Workload_Unoptimized);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (AVX2)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support AVX2.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
+        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        public void fennecs_Raw_AVX2()
+        {
+            Query.Raw(Raw_Workload_AVX2);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (SSE2 / AVX1)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support SSE2.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
+        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        public void fennecs_Raw_SSE2()
+        {
+            Query.Raw(Raw_Workload_SSE2);
+        }
+
+        /// <summary>
+        /// Vectorized Benchmark Contender for fennecs. (Arm64 AdvSIMD)
+        /// </summary>
+        /// <remarks>
+        /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
+        /// </remarks>
+        [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
+        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        public void fennecs_Raw_AdvSIMD()
+        {
+            Query.Raw(Raw_Workload_AdvSIMD);
+        }
+
+        /// <summary>
+        /// Unoptimized workload for fennecs (Raw)
+        /// Treating the Memory Slabs basically as Arrays.
+        /// </summary>
+        /// <remarks>
+        /// However, RyuJIT is able to optimize this workload to a degree,
+        /// especially if we use an explicit assignment instead of a compound assignment
+        /// for our addition. 
+        /// </remarks>
+        private static void Raw_Workload_Unoptimized(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            Span<Component1> c1S = c1V.Span;
+            Span<Component2> c2S = c2V.Span;
+
+            for (int i = 0; i < c1S.Length; i++)
+            {
+                // Compound Assignment is not as optimized as explicit assignment
+                c1S[i].Value = c1S[i].Value + c2S[i].Value;
+            }
+        }
+
+        /// <summary>
+        /// AVX2 workload for fennecs (Raw)
+        /// We use AVX2 intrinsics to vectorize the workload, executing 8 additions in parallel.
+        /// (256 bits)
+        /// </summary>
+        private static void Raw_Workload_AVX2(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector256<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
+                {
+                    Vector256<int> v1 = Avx.LoadVector256(p1 + i);
+                    Vector256<int> v2 = Avx.LoadVector256(p2 + i);
+                    Vector256<int> sum = Avx2.Add(v1, v2);
+
+                    Avx.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
+                }
+            }
+        }
+
+        /// <summary>
+        /// SSE2 workload for fennecs (Raw)
+        /// We use SSE2 (same as AVX1) intrinsics to vectorize the workload, executing 4 additions in parallel.
+        /// (128 bits) 
+        /// </summary>
+        private static void Raw_Workload_SSE2(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
+                {
+                    Vector128<int> v1 = Sse2.LoadVector128(p1 + i);
+                    Vector128<int> v2 = Sse2.LoadVector128(p2 + i);
+                    Vector128<int> sum = Sse2.Add(v1, v2);
+
+                    Sse2.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
+                }
+            }
+        }
+
+        /// <summary>
+        /// AdvSIMD workload for fennecs (Raw)
+        /// We use AdvSIMD intrinsics to vectorize the workload, executing 4 additions in parallel.
+        /// (128 bits) 
+        /// </summary>
+        private static void Raw_Workload_AdvSIMD(Memory<Component1> c1V, Memory<Component2> c2V)
+        {
+            int count = c1V.Length;
+
+            using MemoryHandle mem1 = c1V.Pin();
+            using MemoryHandle mem2 = c2V.Pin();
+
+            unsafe
+            {
+                int* p1 = (int*)mem1.Pointer;
+                int* p2 = (int*)mem2.Pointer;
+
+                int vectorSize = Vector128<int>.Count;
+                int vectorEnd = count - (count % vectorSize);
+                for (int i = 0; i < vectorEnd; i += vectorSize)
+                {
+                    Vector128<int> v1 = AdvSimd.LoadVector128(p1 + i);
+                    Vector128<int> v2 = AdvSimd.LoadVector128(p2 + i);
+                    Vector128<int> sum = AdvSimd.Add(v1, v2);
+
+                    AdvSimd.Store(p1 + i, sum);
+                }
+
+                for (int i = vectorEnd; i < count; i++) // remaining elements
+                {
+                    // Compound Assignment is not as optimized as explicit assignment
+                    p1[i] = p1[i] + p2[i];
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -53,7 +53,7 @@ namespace Ecs.CSharp.Benchmark
                     }
                 }
                 
-                query = World.Query<Component1, Component2>().Build().Warmup();
+                query = World.Query<Component1, Component2>().Compile().Warmup();
             }
             
             public override void Dispose()

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -139,7 +139,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (Raw AVX2)")]
+        [Benchmark(Description = "fennecs (AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -152,7 +152,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (Raw SSE2)")]
+        [Benchmark(Description = "fennecs (SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -165,7 +165,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (Raw AdvSIMD)")]
+        [Benchmark(Description = "fennecs (AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -70,7 +70,7 @@ namespace Ecs.CSharp.Benchmark
         /// They are the most versatile and offer decent single-threaded baseline performance to boot.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (For)")]
+        [Benchmark(Description = "fennecs(For)")]
         public void fennecs_For()
         {
             Query.For(
@@ -95,7 +95,7 @@ namespace Ecs.CSharp.Benchmark
         /// </para>
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = $"fennecs (Job)")]
+        [Benchmark(Description = $"fennecs(Job)")]
         public void fennecs_Job()
         {
             Query.Job(
@@ -123,10 +123,10 @@ namespace Ecs.CSharp.Benchmark
         #region Raw Runners
         
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// </summary>
         [BenchmarkCategory(Categories.Fennecs)]
-        [Benchmark(Description = "fennecs (Raw)")]
+        [Benchmark(Description = "fennecs(Raw)")]
         public void fennecs_Raw()
         {
             Query.Raw(Raw_Workload_Unoptimized);
@@ -139,7 +139,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AVX2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Avx2)]
-        [Benchmark(Description = "fennecs (AVX2)")]
+        [Benchmark(Description = "fennecs(AVX2)")]
         public void fennecs_Raw_AVX2()
         {
             Query.Raw(Raw_Workload_AVX2);
@@ -152,7 +152,7 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support SSE2.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.Sse2)]
-        [Benchmark(Description = "fennecs (SSE2)")]
+        [Benchmark(Description = "fennecs(SSE2)")]
         public void fennecs_Raw_SSE2()
         {
             Query.Raw(Raw_Workload_SSE2);
@@ -165,14 +165,14 @@ namespace Ecs.CSharp.Benchmark
         /// This benchmark is automatically excluded if the current environment does not support AdvSIMD.
         /// </remarks>
         [BenchmarkCategory(Categories.Fennecs, Capabilities.AdvSimd)]
-        [Benchmark(Description = "fennecs (AdvSIMD)")]
+        [Benchmark(Description = "fennecs(AdvSIMD)")]
         public void fennecs_Raw_AdvSIMD()
         {
             Query.Raw(Raw_Workload_AdvSIMD);
         }
 
         /// <summary>
-        /// Unoptimized workload for fennecs (Raw)
+        /// Unoptimized workload for fennecs(Raw)
         /// Treating the Memory Slabs basically as Arrays.
         /// </summary>
         /// <remarks>
@@ -193,7 +193,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AVX2 workload for fennecs (Raw)
+        /// AVX2 workload for fennecs(Raw)
         /// We use AVX2 intrinsics to vectorize the workload, executing 8 additions in parallel.
         /// (256 bits)
         /// </summary>
@@ -229,7 +229,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// SSE2 workload for fennecs (Raw)
+        /// SSE2 workload for fennecs(Raw)
         /// We use SSE2 (same as AVX1) intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>
@@ -265,7 +265,7 @@ namespace Ecs.CSharp.Benchmark
         }
 
         /// <summary>
-        /// AdvSIMD workload for fennecs (Raw)
+        /// AdvSIMD workload for fennecs(Raw)
         /// We use AdvSIMD intrinsics to vectorize the workload, executing 4 additions in parallel.
         /// (128 bits) 
         /// </summary>

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Fennecs.cs
@@ -22,7 +22,7 @@ namespace Ecs.CSharp.Benchmark
 
             public Query<Component1, Component2> query;
 
-            public FennecsContext(int entityCount)
+            public FennecsContext(int entityCount) : base(entityCount)
             {
                 query = World.Query<Component1, Component2>().Build();
                 for (int i = 0; i < entityCount; ++i)
@@ -58,7 +58,7 @@ namespace Ecs.CSharp.Benchmark
         [Benchmark]
         public void Fennecs_Job()
         {
-            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; }, 1024);
+            _fennecs.query.Job(delegate(ref Component1 c1, ref Component2 c2) { c1.Value += c2.Value; });
         }
 
         [BenchmarkCategory(Categories.Fennecs)]

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/_SystemWithTwoComponentsMultipleComposition.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/_SystemWithTwoComponentsMultipleComposition.cs
@@ -2,7 +2,7 @@
 
 namespace Ecs.CSharp.Benchmark
 {
-    [BenchmarkCategory(Categories.System)]
+    [BenchmarkCategory(Categories.System, nameof(SystemWithTwoComponentsMultipleComposition))]
     [MemoryDiagnoser]
 #if CHECK_CACHE_MISSES
     [HardwareCounters(BenchmarkDotNet.Diagnosers.HardwareCounter.CacheMisses)]


### PR DESCRIPTION
### Hello! 
I'm Tiger, the maintainer of 🦊 **fenn**ecs. Thanks for making this nice Benchmark repo, and thanks so much to @xentripetal for building the **fenn**ecs benchmarks. And I'm also a big fan of DefaultEcs. ^^

# Content of this PR

## Framework
- Program.cs now allows a custom `#define RANK_RESULTS`, which adds an Orderer to the Config. While iterating, developers can now more clearly see where their fast/slow methods are at in relation to others.
- it was added as an optional CLI argument so as not to change any existing output of the suite
- the Extension `WithCapabilityExclusions(this IConfig)` was written and Program.cs uses it at startup
- a `CategoryExclusion : IFilter` was created and documented - if this filter is *present*, it will turn off any categories it matches. (it supports a single string)
- this decision of whether to add the filter to turn off affected categories happens in `WithCapabilityExclusions`
- the class `Capabilities` in Categories.cs was created
  - it provides convenient Category string constants that Benchmark writers can add to their Benchmarks to ensure these benchmarks ***only run** if the capability ***is present***. 
  - other benchmarks are unaffected 
  - example: Benchmarks in Category `Capabilities.AdvSIMD` will only show up on appropriate Arm64 platforms. 
  - This means incompatible Benchmarks don't need to fail (causing spam) or return early (thus scoring very high)
- a subset of common vector instruction sets were added to the Capabilities class (but not all of them - didn't want to bloat)
- several Benchmarks now have their own name added to their categories. (using nameof to stay robust with refactors)
  - `SystemWithTwoComponentsMultipleComposition`
  - `SystemWithOneComponents`
  - `SystemWithTwoComponents`
  - `SystemWithThreeComponents`
  - this makes it easier to directly target them from the command line


## **fenn**ecs 0.4.0-beta support
- affects all three entity creation benchmarks for fennecs
- updates the dependency from `fennecs 0.1.1-beta` to the recent release, `fennecs 0.4.0-beta`
- changed project link on README.MD
- had to remove hardcoded chunk sizes (since 0.3.5 uses an internal concurrency heuristic, in 0.5.0 concurrency will be user-configurable again)
- optimized the **fenn**ecs benchmarks in `Category.System`, and wrote additional ones:
- - `Query<>.Raw` Benchmarks now have x64 AVX2, SSE2, and Arm64 AdvSIMD support, with comments
- - delegate pattern replaced with anonymous static methods (delegates still work, just wanted consistency)
- - **fenn**ecs Benchmarks have clearer Benchmark Descriptions
- changed spelling of "fennecs" in categories and comments
- please let me know if the `fennecs (Blit)` benchmark bends the rules too far... 🗡️

Have a good day, and I'm looking forward to your review/feedback. 