### PR TITLE
Friflo.Engine.ECS: update to Friflo.Engine.ECS - 2.0.0-preview.3

### DIFF
--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/FrifloEngineEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/FrifloEngineEcs.cs
@@ -11,15 +11,9 @@ namespace Ecs.CSharp.Benchmark
         public void FrifloEngineEcs()
         {
             EntityStore store = new EntityStore(PidType.UsePidAsId);
-            store.EnsureCapacity(EntityCount);
-
             Archetype archetype = store.GetArchetype(ComponentTypes.Get<Component1>());
-            archetype.EnsureCapacity(EntityCount);
-
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                archetype.CreateEntity();
-            }
+            // returns an enumerator of created entities
+            archetype.CreateEntities(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/FrifloEngineEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/FrifloEngineEcs.cs
@@ -11,15 +11,9 @@ namespace Ecs.CSharp.Benchmark
         public void FrifloEngineEcs()
         {
             EntityStore store = new EntityStore(PidType.UsePidAsId);
-            store.EnsureCapacity(EntityCount);
-
             Archetype archetype = store.GetArchetype(ComponentTypes.Get<Component1, Component2, Component3>());
-            archetype.EnsureCapacity(EntityCount);
-
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                archetype.CreateEntity();
-            }
+            // returns an enumerator of created entities
+            archetype.CreateEntities(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/FrifloEngineEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/FrifloEngineEcs.cs
@@ -11,15 +11,9 @@ namespace Ecs.CSharp.Benchmark
         public void FrifloEngineEcs()
         {
             EntityStore store = new EntityStore(PidType.UsePidAsId);
-            store.EnsureCapacity(EntityCount);
-
             Archetype archetype = store.GetArchetype(ComponentTypes.Get<Component1, Component2>());
-            archetype.EnsureCapacity(EntityCount);
-
-            for (int i = 0; i < EntityCount; ++i)
-            {
-                archetype.CreateEntity();
-            }
+            // returns an enumerator of created entities
+            archetype.CreateEntities(EntityCount);
         }
     }
 }

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -39,7 +39,7 @@
 
     <PackageReference Include="fennecs" Version="0.1.1-beta" />
     
-    <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
+    <PackageReference Include="Friflo.Engine.ECS" Version="2.0.0-preview.3" />
 
     <PackageReference Include="HypEcs" Version="1.2.1" />
     


### PR DESCRIPTION
Improved performance of create entities benchmarks by 3x - 4x.
Introduced `Archtype.CreateEntities(int count)` returning an enumerator of created entities.

[Benchmark results including this PR](https://github.com/friflo/Friflo.Json.Fliox/blob/main/Engine/README.md#ecs-benchmarks)