### PR TITLE
Add Benchmarks for Frent

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -4,6 +4,7 @@
     {
         public const string Arch = "Arch";
         public const string DefaultEcs = "DefaultEcs";
+        public const string Frent = "Frent";
         public const string FrifloEngineEcs = "FrifloEngineEcs";
         public const string HypEcs = "HypEcs";
         public const string LeopotamEcs = "Leopotam.Ecs";

--- a/source/Ecs.CSharp.Benchmark/Contexts/FrentBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/FrentBaseContext.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Frent;
+
+namespace Ecs.CSharp.Benchmark.Contexts
+{
+    internal class FrentBaseContext : IDisposable
+    {
+        public World World { get; } = new();
+        public void Dispose() => World.Dispose();
+
+        internal struct Component1
+        {
+            public int Value;
+        }
+
+        internal struct Component2
+        {
+            public int Value;
+        }
+
+        internal struct Component3
+        {
+            public int Value;
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/Frent.cs
@@ -1,0 +1,38 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Core;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithOneComponent
+    {
+        private static readonly EntityType _entityType = Entity.EntityTypeOf([Component<Component1>.ID], []);
+
+        [Context]
+        private readonly FrentBaseContext _frent;
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent()
+        {
+            World world = _frent.World;
+            world.EnsureCapacity(_entityType, EntityCount);
+
+            for (int i = 0; i < EntityCount; i++)
+                world.Create<Component1>(default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Bulk()
+        {
+            World world = _frent.World;
+            var chunks = world.CreateMany<Component1>(EntityCount);
+
+            for (int i = 0; i < chunks.Span.Length; i++)
+                chunks.Span[i] = new();
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Frent.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Core;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithThreeComponents
+    {
+        private static readonly EntityType _entityType = Entity.EntityTypeOf([Component<Component1>.ID, Component<Component2>.ID, Component<Component3>.ID], []);
+
+        [Context]
+        private readonly FrentBaseContext _frent;
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent()
+        {
+            World world = _frent.World;
+            world.EnsureCapacity(_entityType, EntityCount);
+
+            for (int i = 0; i < EntityCount; i++)
+                world.Create<Component1, Component2, Component3>(default, default, default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Bulk()
+        {
+            World world = _frent.World;
+            var chunks = world.CreateMany<Component1, Component2, Component3>(EntityCount);
+
+            chunks.Span2 = chunks.Span2[..chunks.Span1.Length];
+            chunks.Span3 = chunks.Span3[..chunks.Span1.Length];
+            for (int i = 0; i < chunks.Span1.Length; i++)
+            {
+                chunks.Span1[i] = default;
+                chunks.Span2[i] = default;
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/Frent.cs
@@ -37,6 +37,7 @@ namespace Ecs.CSharp.Benchmark
             {
                 chunks.Span1[i] = default;
                 chunks.Span2[i] = default;
+                chunks.Span3[i] = default;
             }
         }
     }

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/Frent.cs
@@ -1,0 +1,42 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Core;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithTwoComponents
+    {
+        private static readonly EntityType _entityType = Entity.EntityTypeOf([Component<Component1>.ID, Component<Component2>.ID], []);
+
+        [Context]
+        private readonly FrentBaseContext _frent;
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent()
+        {
+            World world = _frent.World;
+            world.EnsureCapacity(_entityType, EntityCount);
+
+            for (int i = 0; i < EntityCount; i++)
+                world.Create<Component1, Component2>(default, default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Bulk()
+        {
+            World world = _frent.World;
+            var chunks = world.CreateMany<Component1, Component2>(EntityCount);
+
+            chunks.Span2 = chunks.Span2[..chunks.Span1.Length];
+            for (int i = 0; i < chunks.Span1.Length; i++)
+            {
+                chunks.Span1[i] = default;
+                chunks.Span2[i] = default;
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup Label="Ecs">
 		<PackageReference Include="Arch" Version="1.2.8.1-alpha" />
-    
+    <PackageReference Include="Frent" Version="0.4.0-beta" />
     <PackageReference Include="DefaultEcs" Version="0.17.2" />
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/Frent.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Systems;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithOneComponent
+    {
+        [Context]
+        private readonly FrentContext _frent;
+
+        private sealed class FrentContext : FrentBaseContext
+        {
+            public FrentContext(int entityCount, int entityPadding)
+            {
+                for (int i = 0; i < entityCount; i++)
+                {
+                    World.Create<Component1>(default);
+                    for (int j = 0; j < entityPadding; j++)
+                    {
+                        World.Create();
+                    }
+                }
+
+                Query = World.Query<With<Component1>>();
+            }
+
+            public Query Query;
+        }
+
+        internal struct Increment : IAction<Component1>
+        {
+            public void Run(ref Component1 t0)
+            {
+                t0.Value++;
+            }
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryInline()
+        {
+            _frent.Query.Inline<Increment, Component1>(default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryDelegate()
+        {
+            _frent.Query.Delegate((ref Component1 c) => c.Value++);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Simd()
+        {
+            Vector256<int> sum = Vector256.Create(1);
+            foreach (ChunkTuple<Component1> chunk in _frent.Query.EnumerateChunks<Component1>())
+            {
+                int len = chunk.Span.Length - (chunk.Span.Length & 7);
+                Span<Vector256<int>> ints = MemoryMarshal.Cast<Component1, Vector256<int>>(chunk.Span.Slice(0, len));
+                for (int i = 0; i < ints.Length; i++)
+                {
+                    ints[i] += sum;
+                }
+
+                for (int i = len; i < chunk.Span.Length; i++)
+                {
+                    chunk.Span[i].Value++;
+                }
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/Frent.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Systems;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithThreeComponents
+    {
+        [Context]
+        private readonly FrentContext _frent;
+
+        private sealed class FrentContext : FrentBaseContext
+        {
+            public FrentContext(int entityCount, int _)
+            {
+                for (int i = 0; i < entityCount; i++)
+                {
+                    World.Create<Component1, Component2, Component3>(default, new() { Value = 1 }, new() { Value = 1 });
+                }
+
+                Query = World.Query<With<Component1>, With<Component2>, With<Component3>>();
+            }
+
+            public Query Query;
+        }
+
+        internal struct Sum : IAction<Component1, Component2, Component3>
+        {
+            public void Run(ref Component1 t0, ref Component2 t1, ref Component3 t2)
+            {
+                t0.Value += t1.Value + t2.Value;
+            }
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryInline()
+        {
+            _frent.Query.Inline<Sum, Component1, Component2, Component3>(default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryDelegate()
+        {
+            _frent.Query.Delegate((ref Component1 c1, ref Component2 c2, ref Component1 c3) => c1.Value += c2.Value + c3.Value);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Simd()
+        {
+            foreach ((var s1, var s2, var s3) in _frent.Query.EnumerateChunks<Component1, Component2, Component3>())
+            {
+                int len = s1.Length - (s1.Length & 7);
+
+                Span<Vector256<int>> ints = MemoryMarshal.Cast<Component1, Vector256<int>>(s1.Slice(0, len));
+                Span<Vector256<int>> a = MemoryMarshal.Cast<Component2, Vector256<int>>(s2.Slice(0, len))[..ints.Length];
+                Span<Vector256<int>> b = MemoryMarshal.Cast<Component3, Vector256<int>>(s3.Slice(0, len))[..ints.Length];
+
+                for (int i = 0; i < ints.Length; i++)
+                    ints[i] += a[i] + b[i];
+
+                for (int i = len; i < s1.Length; i++)
+                    s1[i].Value += s2[i].Value + s3[i].Value;
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/Frent.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Systems;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponents
+    {
+        [Context]
+        private readonly FrentContext _frent;
+
+        internal sealed class FrentContext : FrentBaseContext
+        {
+            public FrentContext(int entityCount, int padding)
+            {
+                for (int i = 0; i < entityCount; i++)
+                {
+                    World.Create<Component1, Component2>(default, new() { Value = 1 });
+                    for (int j = 0; j < padding; j++)
+                    {
+                        World.Create();
+                    }
+                }
+
+                Query = World.Query<With<Component1>, With<Component2>>();
+            }
+
+            public Query Query;
+        }
+
+        internal struct Sum : IAction<Component1, Component2>
+        {
+            public void Run(ref Component1 t0, ref Component2 t1)
+            {
+                t0.Value += t1.Value;
+            }
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryInline()
+        {
+            _frent.Query.Inline<Sum, Component1, Component2>(default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryDelegate()
+        {
+            _frent.Query.Delegate((ref Component1 c1, ref Component2 c2) => c1.Value += c2.Value);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Simd()
+        {
+            foreach ((var s1, var s2) in _frent.Query.EnumerateChunks<Component1, Component2>())
+            {
+                int len = s1.Length - (s1.Length & 7);
+
+                Span<Vector256<int>> ints = MemoryMarshal.Cast<Component1, Vector256<int>>(s1.Slice(0, len));
+                Span<Vector256<int>> a = MemoryMarshal.Cast<Component2, Vector256<int>>(s2.Slice(0, len))[..ints.Length];
+
+                for (int i = 0; i < ints.Length; i++)
+                    ints[i] += a[i];
+
+                for (int i = len; i < s1.Length; i++)
+                    s1[i].Value += s2[i].Value;
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Frent.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/Frent.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using Frent;
+using Frent.Systems;
+using static Ecs.CSharp.Benchmark.Contexts.FrentBaseContext;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponentsMultipleComposition
+    {
+        [Context]
+        private readonly FrentContext _frent;
+        internal sealed class FrentContext : FrentBaseContext
+        {
+            public FrentContext(int entityCount)
+            {
+                for (int i = 0; i < entityCount; i++)
+                {
+                    Entity e = (entityCount % 4) switch
+                    {
+                        0 => World.Create<Component1, Component2, Padding1>(default, new() { Value = 1 }, default),
+                        1 => World.Create<Component1, Component2, Padding2>(default, new() { Value = 1 }, default),
+                        2 => World.Create<Component1, Component2, Padding3>(default, new() { Value = 1 }, default),
+                        _ => World.Create<Component1, Component2, Padding4>(default, new() { Value = 1 }, default),
+                    };
+                }
+
+                Query = World.Query<With<Component1>, With<Component2>>();
+            }
+
+            public Query Query;
+
+            struct Padding1;
+            struct Padding2;
+            struct Padding3;
+            struct Padding4;
+        }
+
+        internal struct Sum : IAction<Component1, Component2>
+        {
+            public void Run(ref Component1 t0, ref Component2 t1)
+            {
+                t0.Value += t1.Value;
+            }
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_QueryInline()
+        {
+            _frent.Query.Inline<Sum, Component1, Component2>(default);
+        }
+
+        [BenchmarkCategory(Categories.Frent)]
+        [Benchmark]
+        public void Frent_Simd()
+        {
+            foreach ((var s1, var s2) in _frent.Query.EnumerateChunks<Component1, Component2>())
+            {
+                int len = s1.Length - (s1.Length & 7);
+
+                Span<Vector256<int>> ints = MemoryMarshal.Cast<Component1, Vector256<int>>(s1.Slice(0, len));
+                Span<Vector256<int>> a = MemoryMarshal.Cast<Component2, Vector256<int>>(s2.Slice(0, len))[..ints.Length];
+
+                for (int i = 0; i < ints.Length; i++)
+                    ints[i] += a[i];
+
+                for (int i = len; i < s1.Length; i++)
+                    s1[i].Value += s2[i].Value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hello! I have made a high performance EC framework and ECS library, [Frent](https://github.com/itsBuggingMe/Frent). I have added benchmarks for my library's supported features.

Some notes:

I have a specific bulk entity creation method which I made a separate entity creation benchmark for - I can remove this one and only keep the 'normal' entity creation API if needed.

I also noticed that Friflo's `SystemWithThreeComponents` doesn't seem to do a `a += b + c` operation and instead does an `a = b + c` operation for both the SIMD and normal system benchmark. Is this intentional?