### PR TITLE
Updated Friflo to v3.2

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -39,7 +39,7 @@
 
     <PackageReference Include="fennecs" Version="0.1.1-beta" />
     
-    <PackageReference Include="Friflo.Engine.ECS" Version="1.14.0" />
+    <PackageReference Include="Friflo.Engine.ECS" Version="3.2.0" />
 
     <PackageReference Include="HypEcs" Version="1.2.1" />
     


### PR DESCRIPTION
Updated Friflo to v3.2. Friflo is _not_ my ECS library, so I've literally just updated the package version and run some of the benchmarks to ensure it still runs, if there have been new capabilities introduced in the newer version, this does not use them.

Short run for `SystemWithTwoComponentsMultipleComposition` vs Myriad. Overall results are still in the same ballpark as the main readme:

```
| Method                          | EntityCount | Mean       | Error      | StdDev    | Gen0   | Gen1   | Allocated |
|-------------------------------- |------------ |-----------:|-----------:|----------:|-------:|-------:|----------:|
| FrifloEngineEcs_SIMD_MonoThread | 100000      |   6.887 us |  0.0764 us | 0.0042 us |      - |      - |         - |
| Myriad_SingleThreadChunk_SIMD   | 100000      |   8.326 us | 14.0177 us | 0.7684 us |      - |      - |         - |
| Myriad_MultiThreadChunk         | 100000      |  25.761 us |  4.4313 us | 0.2429 us | 1.7700 | 0.1526 |   29696 B |
| Myriad_SingleThreadChunk        | 100000      |  35.084 us |  1.0399 us | 0.0570 us |      - |      - |         - |
| FrifloEngineEcs_MonoThread      | 100000      |  39.372 us |  2.4342 us | 0.1334 us |      - |      - |         - |
| FrifloEngineEcs_MultiThread     | 100000      |  39.982 us |  5.5777 us | 0.3057 us |      - |      - |         - |
| Myriad_SingleThread             | 100000      |  46.651 us |  1.6077 us | 0.0881 us |      - |      - |         - |
| Myriad_Delegate                 | 100000      |  57.525 us |  0.7239 us | 0.0397 us |      - |      - |         - |
| Myriad_Enumerable               | 100000      | 135.369 us |  9.2151 us | 0.5051 us |      - |      - |         - |
| Myriad_MultiThread              | 100000      | 150.928 us | 32.7800 us | 1.7968 us | 3.9063 | 0.7324 |   66816 B |
```