### PR TITLE
Fix Benchmark Category (HypEcs)

### DIFF
--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/HypEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/HypEcs.cs
@@ -7,7 +7,7 @@ namespace Ecs.CSharp.Benchmark
     {
         [Context] private readonly HypEcsBaseContext _hypEcs;
 
-        [BenchmarkCategory(Categories.RelEcs)]
+        [BenchmarkCategory(Categories.HypEcs)]
         [Benchmark]
         public void HypEcs()
         {


### PR DESCRIPTION
Fixed incorrect category for CreateEntityWithOneComponent, HypEcs was tagged as RelEcs