### PR TITLE
Fix Benchmark Category (Svelto)

### DIFF
--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/SveltoECS.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/SveltoECS.cs
@@ -80,6 +80,7 @@ namespace Ecs.CSharp.Benchmark
         [Context]
         private readonly SveltoECSContext _sveltoECS;
 
+        [BenchmarkCategory(Categories.SveltoECS)]
         [Benchmark]
         public void SveltoECS() => _sveltoECS.Engine.Update();
     }


### PR DESCRIPTION
Fixed various Svelto benchmarks not having any `BenchmarkCategory` tag at all