### PR TITLE
Add PewPew.Ecs library

### DIFF
--- a/source/Ecs.CSharp.Benchmark/Categories.cs
+++ b/source/Ecs.CSharp.Benchmark/Categories.cs
@@ -11,6 +11,7 @@
         public const string LeopotamEcsLite = "Leopotam.EcsLite";
         public const string MonoGameExtended = "MonoGame.Extended";
         public const string Myriad = "Myriad.ECS";
+        public const string PewPewEcs = "PewPew.Ecs";
         public const string RelEcs = "RelEcs";
         public const string SveltoECS = "Svelto.ECS";
         public const string Morpeh = "Morpeh";

--- a/source/Ecs.CSharp.Benchmark/Contexts/PewPewEcsBaseContext.cs
+++ b/source/Ecs.CSharp.Benchmark/Contexts/PewPewEcsBaseContext.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public struct PPComponent1 : IComponent
+    {
+        public int Value;
+    }
+
+    public struct PPComponent2 : IComponent
+    {
+        public int Value;
+    }
+
+    public struct PPComponent3 : IComponent
+    {
+        public int Value;
+    }
+}
+
+namespace Ecs.CSharp.Benchmark.Contexts
+{
+
+    public class PewPewEcsBaseContext : IDisposable
+    {
+        public HybridWorld HybridWorld { get; }
+
+        public PewPewEcsBaseContext()
+        {
+
+        }
+
+        public PewPewEcsBaseContext(int entityCount)
+        {
+            HybridWorld = WorldFactory.Shared.CreateHybridWorld(c => c.MaxEntitiesCount = entityCount);
+        }
+
+        public PewPewEcsBaseContext(int entityCount, int entityPadding)
+        {
+            HybridWorld = WorldFactory.Shared.CreateHybridWorld(c => c.MaxEntitiesCount = entityCount * entityPadding + entityCount);
+        }
+
+        public virtual void Dispose()
+        {
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithOneComponent/PewPewEcs.cs
@@ -1,0 +1,27 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithOneComponent
+    {
+        [Context]
+        private readonly PewPewEcsBaseContext _pewEcsBaseContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs()
+        {
+            HybridWorld world = WorldFactory.Shared.CreateHybridWorld(c => c.MaxEntitiesCount = EntityCount);
+            world.InitComponent<PPComponent1>();
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                EntityId entityId = world.CreateEntityId();
+                world.AddComponent<PPComponent1>(entityId);
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithThreeComponents/PewPewEcs.cs
@@ -1,0 +1,29 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithThreeComponents
+    {
+        [Context]
+        private readonly PewPewEcsBaseContext _pewEcsBaseContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs()
+        {
+            HybridWorld world = WorldFactory.Shared.CreateHybridWorld(c => c.MaxEntitiesCount = EntityCount);
+            world.InitStaticArchetype<PPComponent1, PPComponent2, PPComponent3>();
+
+            var archetype = world.GetStaticArchetype<PPComponent1, PPComponent2, PPComponent3>();
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                EntityId entityId = world.CreateEntityId();
+                archetype.Create(entityId);
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/CreateEntityWithTwoComponents/PewPewEcs.cs
@@ -1,0 +1,29 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class CreateEntityWithTwoComponents
+    {
+        [Context]
+        private readonly PewPewEcsBaseContext _pewEcsBaseContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs()
+        {
+            HybridWorld world = WorldFactory.Shared.CreateHybridWorld(c => c.MaxEntitiesCount = EntityCount);
+            world.InitStaticArchetype<PPComponent1, PPComponent2>();
+
+            var archetype = world.GetStaticArchetype<PPComponent1, PPComponent2>();
+
+            for (int i = 0; i < EntityCount; ++i)
+            {
+                EntityId entityId = world.CreateEntityId();
+                archetype.Create(entityId);
+            }
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
+++ b/source/Ecs.CSharp.Benchmark/Ecs.CSharp.Benchmark.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
-  
+
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <TargetFramework>net8.0</TargetFramework>
@@ -12,7 +12,7 @@
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <RunAnalyzersDuringLiveAnalysis>true</RunAnalyzersDuringLiveAnalysis>
     <NoWarn>$(NoWarn);NETSDK1206</NoWarn>
-      
+
     <DefineConstants Condition="'$(CheckCacheMisses)' == 'true'">CHECK_CACHE_MISSES</DefineConstants>
   </PropertyGroup>
 
@@ -21,6 +21,7 @@
     <PackageReference Include="Arch.System.SourceGenerator" Version="1.2.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0" PrivateAssets="all" />
     <PackageReference Include="Myriad.ECS" Version="49.0.0" />
+    <PackageReference Include="PewPew.Ecs" Version="1.2.0" />
     <PackageReference Include="Roslynator.Analyzers" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.10.0" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.10.0" PrivateAssets="all" />
@@ -38,11 +39,11 @@
     <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
 
     <PackageReference Include="fennecs" Version="0.1.1-beta" />
-    
+
     <PackageReference Include="Friflo.Engine.ECS" Version="3.6.0" />
 
     <PackageReference Include="HypEcs" Version="1.2.1" />
-    
+
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
 
@@ -58,5 +59,5 @@
     <PackageReference Include="Svelto.Common" Version="3.3.2" />
 		<PackageReference Include="Flecs.NET.Release" Version="3.2.11" />
   </ItemGroup>
-  
+
 </Project>

--- a/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithOneComponent/PewPewEcs.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithOneComponent
+    {
+        [Context]
+        private readonly PewPewEcsContext _pewPewEcsContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs() =>
+            _pewPewEcsContext.HybridWorld.ExecuteQueryWithoutId<OneComponentsQuery, PPComponent1>(_pewPewEcsContext.Query);
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs_Simd() =>
+            _pewPewEcsContext.HybridWorld.ExecuteBatchQuery<OneComponentsBatchQuery, PPComponent1>(_pewPewEcsContext.BatchQuery);
+
+        private sealed class PewPewEcsContext : PewPewEcsBaseContext
+        {
+            public OneComponentsQuery Query;
+            public OneComponentsBatchQuery BatchQuery;
+
+            public PewPewEcsContext(int entityCount, int entityPadding) : base(entityCount, entityPadding)
+            {
+                Query = default;
+
+                HybridWorld.InitComponent<PPComponent1>();
+
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        HybridWorld.CreateEntityId();
+                    }
+
+                    EntityId entityId = HybridWorld.CreateEntityId();
+                    HybridWorld.AddComponent<PPComponent1>(entityId);
+                }
+            }
+        }
+
+        public struct OneComponentsQuery : IQueryWithoutId<PPComponent1>
+        {
+            public void Update(ref PPComponent1 component1)
+            {
+                ++component1.Value;
+            }
+        }
+
+        public struct OneComponentsBatchQuery : IBatchQuery<PPComponent1>
+        {
+            public void BatchUpdate(Span<PPComponent1> component1)
+            {
+                int vectorCount = Vector<int>.Count; // 8
+                int length = component1.Length - (component1.Length % vectorCount);
+
+                Span<Vector<int>> vectors1 = MemoryMarshal.Cast<PPComponent1, Vector<int>>(component1.Slice(0, length));
+
+                for (int i = 0; i < vectors1.Length; i++)
+                    vectors1[i] += Vector<int>.One;
+
+                for (int i = length; i < component1.Length; i++)
+                    component1[i].Value++;
+            }
+
+            public void SparseUpdate(ref PPComponent1 component1) => ++component1.Value;
+        }
+    }
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithThreeComponents/PewPewEcs.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Filters;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithThreeComponents
+    {
+        [Context]
+        private readonly PewPewEcsContext _pewPewEcsContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs() =>
+            _pewPewEcsContext.HybridWorld.ExecuteQueryWithoutId<ThreeComponentsQuery, PPComponent1, PPComponent2, PPComponent3>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.Query);
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs_Simd() =>
+            _pewPewEcsContext.HybridWorld.ExecuteBatchQuery<ThreeComponentsBatchQuery, PPComponent1, PPComponent2, PPComponent3>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.BatchQuery);
+
+        private sealed class PewPewEcsContext : PewPewEcsBaseContext
+        {
+            public FilterDefinition FilterDefinition;
+
+            public ThreeComponentsQuery Query;
+            public ThreeComponentsBatchQuery BatchQuery;
+
+            public PewPewEcsContext(int entityCount, int entityPadding) : base(entityCount, entityPadding)
+            {
+                HybridWorld.InitThreeComponentArchetype();
+
+                Query = default;
+                BatchQuery = default;
+
+                FilterDefinition = new FilterDefinition()
+                    .With<PPComponent1>()
+                    .With<PPComponent2>()
+                    .With<PPComponent3>();
+
+                ThreeComponentArchetype archetype = HybridWorld.GetThreeComponentArchetype();
+
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        EntityId paddingEntityId = HybridWorld.CreateEntityId();
+                        switch (j % 3)
+                        {
+                            case 0:
+                                HybridWorld.AddComponent<PPComponent1>(paddingEntityId);
+                                break;
+
+                            case 1:
+                                HybridWorld.AddComponent<PPComponent2>(paddingEntityId);
+                                break;
+
+                            case 2:
+                                HybridWorld.AddComponent<PPComponent3>(paddingEntityId);
+                                break;
+                        }
+                    }
+
+                    EntityId entityId = HybridWorld.CreateEntityId();
+
+                    ThreeComponent components = archetype.Add(entityId);
+                    components.Component1 = new PPComponent1 { Value = 0 };
+                    components.Component2 = new PPComponent2 { Value = 1 };
+                    components.Component3 = new PPComponent3 { Value = 1 };
+                }
+            }
+        }
+    }
+
+    [PewPew.Ecs.Hybrid.Archetype]
+    public ref struct ThreeComponent
+    {
+        public ref PPComponent1 Component1;
+        public ref PPComponent2 Component2;
+        public ref PPComponent3 Component3;
+
+        public ThreeComponent(ref PPComponent1 component1, ref PPComponent2 component2, ref PPComponent3 component3)
+        {
+            Component1 = ref component1;
+            Component2 = ref component2;
+            Component3 = ref component3;
+        }
+    }
+
+    public struct ThreeComponentsQuery : IQueryWithoutId<PPComponent1, PPComponent2, PPComponent3>
+    {
+        public void Update(ref PPComponent1 component1, ref PPComponent2 component2, ref PPComponent3 component3)
+        {
+            component1.Value += component2.Value + component3.Value;
+        }
+    }
+
+    public struct ThreeComponentsBatchQuery : IBatchQuery<PPComponent1, PPComponent2, PPComponent3>
+    {
+        public void BatchUpdate(Span<PPComponent1> component1, Span<PPComponent2> component2, Span<PPComponent3> component3)
+        {
+            int vectorCount = Vector<int>.Count; // 8
+            int length = component1.Length - (component1.Length % vectorCount);
+
+            Span<Vector<int>> vectors1 = MemoryMarshal.Cast<PPComponent1, Vector<int>>(component1.Slice(0, length));
+            Span<Vector<int>> vectors2 = MemoryMarshal.Cast<PPComponent2, Vector<int>>(component2.Slice(0, length));
+            Span<Vector<int>> vectors3 = MemoryMarshal.Cast<PPComponent3, Vector<int>>(component3.Slice(0, length));
+
+            for (int i = 0; i < vectors1.Length; i++)
+                vectors1[i] += vectors2[i] + vectors3[i];
+
+            for (int i = length; i < component1.Length; i++)
+                component1[i].Value += component2[i].Value + component3[i].Value;
+        }
+
+        public void SparseUpdate(ref PPComponent1 component1, ref PPComponent2 component2, ref PPComponent3 component3)
+        {
+            component1.Value += component2.Value + component3.Value;
+        }
+    }
+
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponents/PewPewEcs.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Numerics;
+using System.Runtime.InteropServices;
+using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Filters;
+using PewPew.Ecs.Hybrid;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponents
+    {
+        [Context]
+        private readonly PewPewEcsContext _pewPewEcsContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs() =>
+            _pewPewEcsContext.HybridWorld.ExecuteQueryWithoutId<TwoComponentsQuery, PPComponent1, PPComponent2>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.Query);
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs_Simd() =>
+            _pewPewEcsContext.HybridWorld.ExecuteBatchQuery<TwoComponentsBatchQuery, PPComponent1, PPComponent2>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.BatchQuery);
+
+        private sealed class PewPewEcsContext : PewPewEcsBaseContext
+        {
+            public FilterDefinition FilterDefinition;
+
+            public TwoComponentsQuery Query;
+            public TwoComponentsBatchQuery BatchQuery;
+
+            public PewPewEcsContext(int entityCount, int entityPadding) : base(entityCount, entityPadding)
+            {
+                HybridWorld.InitTwoComponentArchetype();
+
+                Query = default;
+                BatchQuery = default;
+
+                FilterDefinition = new FilterDefinition()
+                    .With<PPComponent1>()
+                    .With<PPComponent2>();
+
+                TwoComponentArchetype archetype = HybridWorld.GetTwoComponentArchetype();
+
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    for (int j = 0; j < entityPadding; ++j)
+                    {
+                        EntityId paddingEntityId = HybridWorld.CreateEntityId();
+                        switch (j % 2)
+                        {
+                            case 0:
+                                HybridWorld.AddComponent<PPComponent1>(paddingEntityId);
+                                break;
+
+                            case 1:
+                                HybridWorld.AddComponent<PPComponent2>(paddingEntityId);
+                                break;
+                        }
+                    }
+
+                    EntityId entityId = HybridWorld.CreateEntityId();
+
+                    TwoComponent components = archetype.Add(entityId);
+                    components.Component1 = new PPComponent1 { Value = 0 };
+                    components.Component2 = new PPComponent2 { Value = 1 };
+                }
+            }
+        }
+    }
+
+    [PewPew.Ecs.Hybrid.Archetype]
+    public ref struct TwoComponent
+    {
+        public ref PPComponent1 Component1;
+        public ref PPComponent2 Component2;
+
+        public TwoComponent(ref PPComponent1 component1, ref PPComponent2 component2)
+        {
+            Component1 = ref component1;
+            Component2 = ref component2;
+        }
+    }
+
+    public struct TwoComponentsQuery : IQueryWithoutId<PPComponent1, PPComponent2>
+    {
+        public void Update(ref PPComponent1 component1, ref PPComponent2 component2)
+        {
+            component1.Value += component2.Value;
+        }
+    }
+
+    public struct TwoComponentsBatchQuery : IBatchQuery<PPComponent1, PPComponent2>
+    {
+        public void BatchUpdate(Span<PPComponent1> component1, Span<PPComponent2> component2)
+        {
+            int vectorCount = Vector<int>.Count; // 8
+            int length = component1.Length - (component1.Length % vectorCount);
+
+            Span<Vector<int>> vectors1 = MemoryMarshal.Cast<PPComponent1, Vector<int>>(component1.Slice(0, length));
+            Span<Vector<int>> vectors2 = MemoryMarshal.Cast<PPComponent2, Vector<int>>(component2.Slice(0, length));
+
+            for (int i = 0; i < vectors1.Length; i++)
+                vectors1[i] += vectors2[i];
+
+            for (int i = length; i < component1.Length; i++)
+                component1[i].Value += component2[i].Value;
+        }
+
+        public void SparseUpdate(ref PPComponent1 component1, ref PPComponent2 component2)
+        {
+            component1.Value += component2.Value;
+        }
+    }
+
+}

--- a/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/PewPewEcs.cs
+++ b/source/Ecs.CSharp.Benchmark/SystemWithTwoComponentsMultipleComposition/PewPewEcs.cs
@@ -1,0 +1,90 @@
+﻿using BenchmarkDotNet.Attributes;
+using Ecs.CSharp.Benchmark.Contexts;
+using PewPew.Ecs.Core;
+using PewPew.Ecs.Filters;
+using PewPew.Ecs.Hybrid;
+using IComponent = PewPew.Ecs.Core.IComponent;
+
+namespace Ecs.CSharp.Benchmark
+{
+    public partial class SystemWithTwoComponentsMultipleComposition
+    {
+        [Context]
+        private readonly PewPewEcsContext _pewPewEcsContext;
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs() =>
+            _pewPewEcsContext.HybridWorld.ExecuteQueryWithoutId<TwoComponentsQuery, PPComponent1, PPComponent2>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.Query);
+
+        [BenchmarkCategory(Categories.PewPewEcs)]
+        [Benchmark]
+        public void PewPewEcs_Simd() =>
+            _pewPewEcsContext.HybridWorld.ExecuteBatchQuery<TwoComponentsBatchQuery, PPComponent1, PPComponent2>(
+                _pewPewEcsContext.FilterDefinition,
+                _pewPewEcsContext.BatchQuery);
+
+        private sealed class PewPewEcsContext : PewPewEcsBaseContext
+        {
+            public FilterDefinition FilterDefinition;
+
+            public TwoComponentsQuery Query;
+            public TwoComponentsBatchQuery BatchQuery;
+
+            public PewPewEcsContext(int entityCount) : base(entityCount)
+            {
+                HybridWorld.InitStaticArchetype<PPComponent1, PPComponent2, Padding1>();
+                HybridWorld.InitStaticArchetype<PPComponent1, PPComponent2, Padding2>();
+                HybridWorld.InitStaticArchetype<PPComponent1, PPComponent2, Padding3>();
+                HybridWorld.InitStaticArchetype<PPComponent1, PPComponent2, Padding4>();
+
+                Query = default;
+                BatchQuery = default;
+
+                FilterDefinition = new FilterDefinition()
+                    .With<PPComponent1>()
+                    .With<PPComponent2>();
+
+                var staticArchetype1 = HybridWorld.GetStaticArchetype<PPComponent1, PPComponent2, Padding1>();
+                var staticArchetype2 = HybridWorld.GetStaticArchetype<PPComponent1, PPComponent2, Padding2>();
+                var staticArchetype3 = HybridWorld.GetStaticArchetype<PPComponent1, PPComponent2, Padding3>();
+                var staticArchetype4 = HybridWorld.GetStaticArchetype<PPComponent1, PPComponent2, Padding4>();
+
+                for (int i = 0; i < entityCount; ++i)
+                {
+                    EntityId entityId = HybridWorld.CreateEntityId();
+
+                    switch (i % 4)
+                    {
+                        case 0:
+                            staticArchetype1.Add(entityId, new PPComponent1 { Value = 0 }, new PPComponent2 { Value = 1 }, new Padding1());
+                            break;
+
+                        case 1:
+                            staticArchetype2.Add(entityId, new PPComponent1 { Value = 0 }, new PPComponent2 { Value = 1 }, new Padding2());
+                            break;
+
+                        case 2:
+                            staticArchetype3.Add(entityId, new PPComponent1 { Value = 0 }, new PPComponent2 { Value = 1 }, new Padding3());
+                            break;
+
+                        case 3:
+                            staticArchetype4.Add(entityId, new PPComponent1 { Value = 0 }, new PPComponent2 { Value = 1 }, new Padding4());
+                            break;
+                    }
+                }
+            }
+
+            private record struct Padding1() : IComponent;
+
+            private record struct Padding2() : IComponent;
+
+            private record struct Padding3() : IComponent;
+
+            private record struct Padding4() : IComponent;
+        }
+    }
+
+}


### PR DESCRIPTION
Adds https://github.com/Levchenkov/PewPew.Ecs library. Looks quite good.

BenchmarkDotNet v0.13.12, Windows 11 (10.0.26200.8246)  
12th Gen Intel Core i7-12700, 1 CPU, 20 logical and 12 physical cores  
.NET SDK 10.0.202  
[Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2  
DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2

SystemWithOneComponent:

| Method                          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Allocated |  
|-------------------------------- |------------ |-------------- |---------:|---------:|---------:|----------:|  
| TinyEcs_Each                    | 100000      | 10            | 16.39 us | 0.052 us | 0.041 us |         - |  
| Frent_QueryInline               | 100000      | 10            | 21.16 us | 0.141 us | 0.110 us |         - |  
| **PewPewEcs**                       | 100000      | 10            | 23.31 us | 0.096 us | 0.085 us |         - |  
| HypEcs_MonoThread               | 100000      | 10            | 31.43 us | 0.493 us | 0.461 us |      72 B |  
| FrifloEngineEcs_MonoThread      | 100000      | 10            | 37.50 us | 0.516 us | 0.458 us |         - |  
| Arch_MonoThread_SourceGenerated | 100000      | 10            | 42.70 us | 0.577 us | 0.540 us |         - |

SystemWithTwoComponents:

| Method                          | EntityCount | EntityPadding | Mean     | Error    | StdDev   | Allocated |  
|-------------------------------- |------------ |-------------- |---------:|---------:|---------:|----------:|  
| TinyEcs_Each                    | 100000      | 10            | 23.47 us | 0.467 us | 1.254 us |         - |  
| **PewPewEcs**                       | 100000      | 10            | 25.92 us | 0.162 us | 0.144 us |         - |  
| Frent_QueryInline               | 100000      | 10            | 26.27 us | 0.512 us | 0.479 us |         - |  
| HypEcs_MonoThread               | 100000      | 10            | 35.15 us | 0.270 us | 0.211 us |     112 B |  
| Arch_MonoThread_SourceGenerated | 100000      | 10            | 43.77 us | 0.445 us | 0.416 us |         - |  
| FrifloEngineEcs_MonoThread      | 100000      | 10            | 44.10 us | 0.529 us | 0.469 us |         - |

SystemWithThreeComponents:

| Method                          | EntityCount | EntityPadding | Mean      | Error    | StdDev   | Allocated |  
|-------------------------------- |------------ |-------------- |----------:|---------:|---------:|----------:|  
| TinyEcs_Each                    | 100000      | 10            |  34.16 us | 0.602 us | 0.920 us |         - |  
| Frent_QueryInline               | 100000      | 10            |  36.32 us | 0.725 us | 1.016 us |         - |  
| **PewPewEcs**                       | 100000      | 10            |  36.36 us | 0.710 us | 1.186 us |         - |  
| HypEcs_MonoThread               | 100000      | 10            |  41.63 us | 0.812 us | 0.903 us |     152 B |  
| FrifloEngineEcs_MonoThread      | 100000      | 10            |  61.70 us | 1.205 us | 1.127 us |         - |  
| Arch_MonoThread_SourceGenerated | 100000      | 10            | 129.03 us | 2.069 us | 1.935 us |         - |

SystemWithTwoComponentsMultipleComposition:

| Method                          | EntityCount | Mean       | Error     | StdDev    | Gen0   | Allocated |  
|-------------------------------- |------------ |-----------:|----------:|----------:|-------:|----------:|  
| **PewPewEcs_Simd**                  | 100000      |   7.703 us | 0.0933 us | 0.0779 us |      - |         - |  
| Frent_Simd                      | 100000      |   8.710 us | 0.1422 us | 0.1261 us |      - |         - |  
| FrifloEngineEcs_SIMD_MonoThread | 100000      |  10.078 us | 0.1376 us | 0.1149 us |      - |         - |  
| TinyEcs_Each                    | 100000      |  23.021 us | 0.2907 us | 0.2270 us |      - |         - |  
| **PewPewEcs**                       | 100000      |  27.369 us | 0.2530 us | 0.2367 us |      - |         - |  
| Frent_QueryInline               | 100000      |  27.514 us | 0.5233 us | 0.4895 us |      - |         - |  
| HypEcs_MonoThread               | 100000      |  34.228 us | 0.4315 us | 0.3603 us |      - |     352 B |  
| Arch_MonoThread_SourceGenerated | 100000      |  43.797 us | 0.4925 us | 0.4607 us |      - |         - |  
| FrifloEngineEcs_MonoThread      | 100000      |  46.419 us | 0.7743 us | 0.7243 us |      - |         - |  
| Arch                            | 100000      |  55.124 us | 0.7278 us | 0.6808 us |      - |         - |